### PR TITLE
Docs: try D2 sequence diagram in 06_runtime_view.adoc

### DIFF
--- a/docs/src/06_runtime_view.adoc
+++ b/docs/src/06_runtime_view.adoc
@@ -48,16 +48,30 @@ building block instances depicted in this diagram.>_
 
 It is possible to use a sequence diagram:
 
-[plantuml,"Sequence diagram",png]
+[d2, diagram_prototype, svg, pad=10, sketch=true, width=400, height=400]
 ----
-actor Alice
-actor Bob
-database Pod as "Bob's Pod"
-Alice -> Bob: Authentication Request
-Bob --> Alice: Authentication Response
-Alice  --> Pod: Store route
-Alice -> Bob: Another authentication Request
-Alice <-- Bob: another authentication Response
+shape: sequence_diagram
+
+alice: Alice
+alice.shape: c4-person
+
+bob: Bob
+bob.shape: c4-person
+
+bob_pod: "Bob's\nPod"
+bob_pod.shape: cylinder
+
+alice -> bob: Authentication request
+bob -> alice: Authentication response {
+  style.stroke-dash: 2
+}
+alice -> bob_pod: Store route {
+  style.stroke-dash: 2
+}
+alice -> bob: Authentication request
+bob -> alice: Authentication response {
+  style.stroke-dash: 2
+}
 ----
 
 === <Runtime Scenario 2>


### PR DESCRIPTION
# Try D2 sequence diagram in 06_runtime_view.adoc

## PR description:

I’m running a small **trial** to evaluate D2 as a diagramming tool for our AsciiDoc/arc42 documentation.
**Closes: Issue #5**

## What changed

- I replaced the PlantUML sequence diagram in `06_runtime_view.adoc` with an equivalent D2 sequence diagram (D2 supports sequence diagrams via `shape: sequence_diagram`).
- I kept the rest of the runtime view content unchanged.


## Why

I want to check whether D2 gives me better styling/customization and an easier workflow for maintaining sequence diagrams long-term.


## How to test

- Build the documentation with my changes locally using the usual build command(s).
- Confirm the runtime view diagram renders correctly in the generated output (SVG as configured).
- If you build the docs locally with my changes and the diagram doesn’t show up, it’s because you need the `d2` compiler installed in your environment. The installation link is in the next section.


## Links (D2)

- D2 sequence diagrams: https://d2lang.com/tour/sequence-diagrams/
- D2 compiler install guide: https://github.com/terrastruct/d2/blob/master/docs/INSTALL.md
- VS Code extension (requires D2 installed): https://github.com/terrastruct/d2-vscode


## Follow-up (only if we adopt D2)

If this PR is accepted and we confirm D2 is the diagramming tool we’ll use going forward, I’ll create a pinned GitHub Discussion post that points to the documentation and setup links above.


## Acceptance criteria

- [x] The diagram renders correctly in the local build.
- [x] The D2 version is at least as readable as the current PlantUML version.
- [x] Reviewers agree this is a good direction (or request adjustments).