### PR TITLE
Deploy mechanism is now written in a separate deploy.sh

### DIFF
--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+APP_DIR=$HOME/yovi
+mkdir -p "$APP_DIR"
+cd "$APP_DIR"
+
+# Create .env file
+cat > .env << EOF
+NODE_ENV=production
+MARIADB_ROOT_PASSWORD="$MARIADB_ROOT_PASSWORD"
+MARIADB_USER="$MARIADB_USER"
+MARIADB_PASSWORD="$MARIADB_PASSWORD"
+JWT_SECRET="$JWT_SECRET"
+EOF
+chmod 600 .env
+
+# Create directories
+mkdir -p users/monitoring/prometheus
+mkdir -p users/monitoring/grafana/provisioning/datasources
+mkdir -p users/monitoring/grafana/provisioning/dashboards
+
+# Download files
+wget -q "https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/master/docker-compose.yml" -O docker-compose.yml
+wget -q "https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/master/users/schema.sql" -O users/schema.sql
+wget -q "https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/master/users/monitoring/prometheus/prometheus.yml" -O users/monitoring/prometheus/prometheus.yml
+wget -q "https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/master/users/monitoring/grafana/provisioning/datasources/datasource.yml" -O users/monitoring/grafana/provisioning/datasources/datasource.yml
+wget -q "https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/master/users/monitoring/grafana/provisioning/dashboards/dashboard.yml" -O users/monitoring/grafana/provisioning/dashboards/dashboard.yml
+wget -q "https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/master/users/monitoring/grafana/provisioning/dashboards/dashboard.json" -O users/monitoring/grafana/provisioning/dashboards/dashboard.json
+
+# Deploy
+docker compose down
+docker compose up -d --pull always || {
+  echo "Docker Compose failed. Showing logs:"
+  docker compose logs
+  exit 1
+}
+
+echo "Deploy complete!"

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -188,31 +188,17 @@ jobs:
     needs: [docker-push-users, docker-push-webapp, docker-push-gamey]
     steps:
       - name: Deploy over SSH
-        uses: fifsky/ssh-action@master
+        uses: appleboy/ssh-action@v1
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          MARIADB_ROOT_PASSWORD: ${{ secrets.MARIADB_ROOT_PASSWORD }}
+          MARIADB_USER: ${{ secrets.MARIADB_USER }}
+          MARIADB_PASSWORD: ${{ secrets.MARIADB_PASSWORD }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
-          user: ${{ secrets.DEPLOY_USER }}
+          username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_KEY }}
-          command: |
-            set -e
-
-            APP_DIR=$HOME/yovi
-            mkdir -p "$APP_DIR"
-            cd "$APP_DIR"
-
-            cat > .env <<'EOF'
-            NODE_ENV=production
-            MARIADB_ROOT_PASSWORD=${{ secrets.MARIADB_ROOT_PASSWORD }}
-            MARIADB_USER=${{ secrets.MARIADB_USER }}
-            MARIADB_PASSWORD=${{ secrets.MARIADB_PASSWORD }}
-            JWT_SECRET=${{ secrets.JWT_SECRET }}
-            EOF
-            chmod 600 .env
-
-            wget -q https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/master/docker-compose.yml -O docker-compose.yml
-
-            docker compose down
-            docker compose up -d --pull always || {
-              docker compose logs
-              exit 1
-            }
+          envs: REPO_OWNER,REPO_NAME,MARIADB_ROOT_PASSWORD,MARIADB_USER,MARIADB_PASSWORD,JWT_SECRET
+          script_path: deploy.sh


### PR DESCRIPTION
# Deploy mechanism is now written in a separate deploy.sh
I changed the release-deploy.yml workflow to use another gh-action that allowed me to run a shell script instead of loading all the commands into the action itself.