### PR TITLE
Fix local deployment by introducing dev-specific Nginx configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docs/build/
 webapp/.env
 .vscode/
 dist/
+certs/
 
 personal.md
 flamegraph.svg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ services:
     networks:
       - monitor-net
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
       interval: 10s
       timeout: 5s
       retries: 15
       start_period: 60s
     restart: unless-stopped
-  
+
   users:
     build: ./users
     container_name: users
@@ -43,7 +43,7 @@ services:
     networks:
       - monitor-net
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3000/health || wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:3000/health || wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 15
@@ -57,15 +57,17 @@ services:
     container_name: webapp
     image: ghcr.io/arquisoft/yovi_en2b-webapp:latest
     ports:
-    - "80:80"
-    - "443:443"
+      - "80:80"
+      - "443:443"
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
     volumes:
-    - /etc/nginx/certs:/etc/nginx/certs:ro
+      - ./webapp/nginx/certs:/etc/nginx/certs:ro
     depends_on:
       users:
         condition: service_healthy
     networks:
-    - monitor-net
+      - monitor-net
 
   gamey:
     build: ./gamey
@@ -94,8 +96,8 @@ services:
     volumes:
       - ./users/monitoring/grafana/provisioning:/etc/grafana/provisioning
     environment:
-    - GF_LOG_LEVEL=error
-    - GF_LOG_MODE=console  
+      - GF_LOG_LEVEL=error
+      - GF_LOG_MODE=console
     networks:
       - monitor-net
 

--- a/users/openapi.yaml
+++ b/users/openapi.yaml
@@ -4,10 +4,10 @@ info:
   description: REST API to manage YOVI application users
   version: 1.0.0
 servers:
-  - url: https://api.micrati.com/users
-    description: Production server
-  - url: http://localhost:3000
-    description: Local server
+- url: https://api.micrati.com/users
+  description: Production server
+- url: http://api.localhost/users
+  description: Local server
 
 paths:
   /health:
@@ -30,7 +30,7 @@ paths:
     post:
       summary: Register new user
       tags:
-        - Authentication
+      - Authentication
       requestBody:
         required: true
         content:
@@ -38,9 +38,9 @@ paths:
             schema:
               type: object
               required:
-                - username
-                - email
-                - password
+              - username
+              - email
+              - password
               properties:
                 username:
                   type: string
@@ -80,7 +80,7 @@ paths:
                         example: player1@example.com
                       role:
                         type: string
-                        enum: [player, admin]
+                        enum: [ player, admin ]
                         example: player
                       createdAt:
                         type: string
@@ -112,7 +112,7 @@ paths:
     post:
       summary: User login
       tags:
-        - Authentication
+      - Authentication
       requestBody:
         required: true
         content:
@@ -120,8 +120,8 @@ paths:
             schema:
               type: object
               required:
-                - email
-                - password
+              - email
+              - password
               properties:
                 email:
                   type: string
@@ -160,7 +160,7 @@ paths:
                         example: player1@example.com
                       role:
                         type: string
-                        enum: [player, admin]
+                        enum: [ player, admin ]
                         example: player
         "400":
           description: Missing required fields or invalid JSON
@@ -195,9 +195,9 @@ paths:
     get:
       summary: Get authenticated user profile
       tags:
-        - Authentication
+      - Authentication
       security:
-        - bearerAuth: []
+      - bearerAuth: []
       responses:
         "200":
           description: User profile
@@ -248,9 +248,9 @@ paths:
     put:
       summary: Update user profile
       tags:
-        - Authentication
+      - Authentication
       security:
-        - bearerAuth: []
+      - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -291,7 +291,7 @@ paths:
                         example: newemail@example.com
                       role:
                         type: string
-                        enum: [player, admin]
+                        enum: [ player, admin ]
                         example: player
         "400":
           description: Validation error or username/email already exists
@@ -335,9 +335,9 @@ paths:
     put:
       summary: Change user password
       tags:
-        - Authentication
+      - Authentication
       security:
-        - bearerAuth: []
+      - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -345,8 +345,8 @@ paths:
             schema:
               type: object
               required:
-                - currentPassword
-                - newPassword
+              - currentPassword
+              - newPassword
               properties:
                 currentPassword:
                   type: string
@@ -409,9 +409,9 @@ paths:
     delete:
       summary: Deactivate user account
       tags:
-        - Authentication
+      - Authentication
       security:
-        - bearerAuth: []
+      - bearerAuth: []
       responses:
         "200":
           description: Account deactivated successfully
@@ -448,7 +448,7 @@ paths:
     get:
       summary: Prometheus metrics
       tags:
-        - Monitoring
+      - Monitoring
       responses:
         "200":
           description: Metrics in Prometheus format
@@ -485,7 +485,7 @@ components:
           example: player1@example.com
         role:
           type: string
-          enum: [player, admin]
+          enum: [ player, admin ]
           example: player
         createdAt:
           type: string

--- a/users/src/app.ts
+++ b/users/src/app.ts
@@ -17,6 +17,8 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+console.log(`Starting nodejs server with env: ` + process.env.NODE_ENV);
+
 // CROSS-ORIGIN RESOURCE SHARING
 app.use(cors({
     origin: process.env.NODE_ENV === 'production'
@@ -62,7 +64,7 @@ try {
     const swaggerPath = path.join(__dirname, '../openapi.yaml');
     const swaggerDocument = YAML.load(fs.readFileSync(swaggerPath, 'utf8')) as object;
     app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
-    console.log('Swagger UI available at /api-docs');
+    console.log('Swagger UI running');
 } catch (error) {
     console.warn('Could not load openapi.yaml:', error);
 }
@@ -101,10 +103,11 @@ const startServer = async () => {
         console.log('MariaDB database connected');
 
         app.listen(PORT, () => {
-            console.log(`Server running at http://localhost:${PORT}`);
-            console.log(`Prometheus metrics: http://localhost:${PORT}/metrics`);
-            console.log(`Swagger documentation: http://localhost:${PORT}/api-docs`);
-            console.log(`Health check: http://localhost:${PORT}/health`);
+            console.log(`Server running at http://api.localhost/users`);
+            console.log(`Swagger documentation: http://api.localhost/users/api-docs`);
+            console.log(`Health check: http://api.localhost/users/health`);
+            console.log(`Prometheus metrics: http://monitoring.localhost/prometheus`);
+            console.log(`Grafana dashboard: http://monitoring.localhost/grafana`);
         });
     } catch (error) {
         console.error('Error starting server:', error);

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -18,7 +18,18 @@ FROM nginx:stable-alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Copy nginx config
-COPY nginx.conf /etc/nginx/conf.d/webapp.conf
+COPY nginx/snippets/ /etc/nginx/snippets/
+COPY nginx/nginx.prod.conf /etc/nginx/prod.conf
+COPY nginx/nginx.dev.conf /etc/nginx/dev.conf
 
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+# Copy entrypoint script
+COPY nginx/start-nginx.sh /start-nginx.sh
+RUN chmod +x /start-nginx.sh
+
+# Remove default nginx config and dependant scripts
+RUN rm -f /etc/nginx/conf.d/default.conf
+RUN rm -f /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
+
+EXPOSE 80 443
+
+ENTRYPOINT ["/start-nginx.sh"]

--- a/webapp/nginx/nginx.dev.conf
+++ b/webapp/nginx/nginx.dev.conf
@@ -1,0 +1,66 @@
+resolver 127.0.0.11 ipv6=off;
+
+upstream users      { server users:3000; }
+upstream gamey      { server gamey:4000; }
+upstream prometheus { server prometheus:9090; }
+upstream grafana    { server grafana:3000; }
+
+# SPA -> http://localhost
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-store";
+    }
+}
+
+# API -> http://api.localhost
+server {
+    listen 80;
+    server_name api.localhost;
+
+    add_header "Access-Control-Allow-Origin"  "http://localhost" always;
+    add_header "Access-Control-Allow-Methods" "GET,POST,PUT,DELETE,OPTIONS,PATCH" always;
+    add_header "Access-Control-Allow-Headers" "Content-Type,Authorization" always;
+
+    if ($request_method = 'OPTIONS') { return 204; }
+
+    location /users/ {
+        proxy_pass http://users/;
+        include /etc/nginx/snippets/proxy-headers.conf;
+        proxy_redirect / /users/;
+        proxy_redirect http:// /users/;
+    }
+
+    location /gamey/ {
+        proxy_pass http://gamey/;
+        include /etc/nginx/snippets/proxy-headers.conf;
+        proxy_redirect / /gamey/;
+        proxy_redirect http:// /gamey/; 
+    }
+}
+
+# Monitoring -> http://monitoring.localhost
+server {
+    listen 80;
+    server_name monitoring.localhost;
+
+    location /prometheus/ {
+        proxy_pass http://prometheus/;
+        include /etc/nginx/snippets/proxy-headers.conf;
+        proxy_redirect / /prometheus/;
+        proxy_redirect http:// /prometheus/;
+    }
+
+    location /grafana/ {
+        proxy_pass http://grafana/;
+        include /etc/nginx/snippets/proxy-headers.conf;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_redirect / /grafana/;
+        proxy_redirect http:// /grafana/;
+    }
+}

--- a/webapp/nginx/nginx.prod.conf
+++ b/webapp/nginx/nginx.prod.conf
@@ -23,7 +23,7 @@ server {
     return 444;
 }
 
-# micrati.com - Frontend SPA
+# SPA -> https://micrati.com
 server {
     listen 443 ssl;
     http2 on;
@@ -32,6 +32,11 @@ server {
     ssl_certificate /etc/nginx/certs/fullchain.pem;
     ssl_certificate_key /etc/nginx/certs/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
+
+    # CORS
+    add_header "Access-Control-Allow-Origin" "https://api.micrati.com" always;
+    add_header "Access-Control-Allow-Methods" "GET,POST,PUT,DELETE,OPTIONS,PATCH" always;
+    add_header "Access-Control-Allow-Headers" "Content-Type,Authorization" always;
     
     location / {
         root /usr/share/nginx/html;
@@ -40,7 +45,7 @@ server {
     }
 }
 
-# api.micrati.com - Backend proxy
+# API -> https://api.micrati.com
 server {
     listen 443 ssl;
     http2 on;
@@ -59,28 +64,20 @@ server {
     
     location /users/ {
         proxy_pass http://users/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
+        include /etc/nginx/snippets/proxy-headers.conf;
         proxy_redirect / /users/;
         proxy_redirect http:// /users/;
     }
 
     location /gamey/ {
         proxy_pass http://gamey/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
+        include /etc/nginx/snippets/proxy-headers.conf;
         proxy_redirect / /gamey/;
         proxy_redirect http:// /gamey/;        
     }
 }
 
-# monitoring.micrati.com - Monitoring
+# Monitoring -> https://monitoring.micrati.com
 server {
     listen 443 ssl;
     http2 on;
@@ -92,24 +89,16 @@ server {
     
     location /prometheus/ {
         proxy_pass http://prometheus/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
+        include /etc/nginx/snippets/proxy-headers.conf;
         proxy_redirect / /prometheus/;
         proxy_redirect http:// /prometheus/;
     }
     
     location /grafana/ {
         proxy_pass http://grafana/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        include /etc/nginx/snippets/proxy-headers.conf;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-
         proxy_redirect / /grafana/;
         proxy_redirect http:// /grafana/;
     }

--- a/webapp/nginx/snippets/proxy-headers.conf
+++ b/webapp/nginx/snippets/proxy-headers.conf
@@ -1,0 +1,4 @@
+proxy_set_header Host              $host;
+proxy_set_header X-Real-IP         $remote_addr;
+proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;

--- a/webapp/nginx/start-nginx.sh
+++ b/webapp/nginx/start-nginx.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+ENV=${NODE_ENV:-production}
+
+echo "Starting nginx server with env: $ENV"
+
+if [ "$ENV" = "production" ]; then
+    cp /etc/nginx/prod.conf /etc/nginx/conf.d/prod.conf
+else
+    cp /etc/nginx/dev.conf /etc/nginx/conf.d/dev.conf
+fi
+
+exec /docker-entrypoint.sh nginx -g "daemon off;"


### PR DESCRIPTION
# Fix local deployment by introducing dev-specific Nginx configuration

**Closes #81 issue**

## What I did
To fix the issue where local deployments failed because the Nginx reverse proxy was strictly configured for production (requiring SSL certs and pointing to micrati.com).

## Changes made
Added nginx.dev.conf: A new, dev-friendly Nginx configuration that:

- Listens purely on HTTP (port 80).
- Uses local domains (localhost, api.localhost, monitoring.localhost).
- Handles local CORS correctly (e.g., allowing requests from the Vite dev server).
- Does not require SSL certificates.

## Dynamic Config Selection
I added a custom start-nginx.sh entrypoint script to the Nginx Docker container. It dynamically copies either the dev or prod config based on the environment before starting Nginx.

## Environment Variable
To control which config is loaded, I am reusing the existing NODE_ENV variable.

> Note on naming: I realize NODE_ENV isn't the most accurate name for an Nginx container variable, but I opted to reuse it for simplicity and to avoid breaking existing deployment pipelines or .env files. If it equals production, the prod config is loaded; otherwise, it defaults to dev.

## How to test
Run `docker compose up --build` locally (including `NODE_ENV=development` in your local `.env` file).

The application should start cleanly on port 80 without SSL errors or requiring DNS mocking.