### PR TITLE
Disabled online match option

### DIFF
--- a/webapp/src/components/ModeCard.tsx
+++ b/webapp/src/components/ModeCard.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/utils'
 interface ModeCardProps {
   mode: GameMode
   onSelect: () => void
+  disabled?: boolean
 }
 
 const modeInfo: Record<GameMode, {
@@ -30,38 +31,49 @@ const modeInfo: Record<GameMode, {
   },
 }
 
-export function ModeCard({ mode, onSelect }: ModeCardProps) {
+export function ModeCard({ mode, onSelect , disabled }: ModeCardProps) {
   const info = modeInfo[mode]
   const Icon = info.icon
 
   return (
     <Card
       className={cn(
-        'cursor-pointer group hover:border-primary/50 transition-all',
-        'hover:shadow-lg hover:shadow-primary/5'
+        'transition-all',
+        disabled 
+        ? 'opacity-50 cursor-not-allowed'
+        : 'cursor-pointer group hover:border-primary/50 hover:shadow-lg hover:shadow-primary/5'
       )}
-      onClick={onSelect}
+      onClick={!disabled ? onSelect : undefined}
       role="button"
-      tabIndex={0}
+      tabIndex={disabled ? -1 : 0}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
+        if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
           onSelect()
         }
       }}
     >
       <CardHeader>
-        <div className="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center mb-2 group-hover:bg-primary/20 transition-colors">
+        <div className= {cn(
+          "w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center mb-2 transition-colors",
+          !disabled && 'group-hover:bg-primary/20'
+        )}>
           <Icon className="w-6 h-6 text-primary" />
         </div>
         <CardTitle className="flex items-center justify-between">
           {info.title}
-          <ArrowRight className="w-5 h-5 text-muted-foreground group-hover:text-primary group-hover:translate-x-1 transition-all" />
+          {disabled
+            ? <span className="text-xs font-normal text-muted-foreground">Soon</span>
+            : <ArrowRight className="w-5 h-5 text-muted-foreground group-hover:text-primary group-hover:translate-x-1 transition-all" />
+          }
         </CardTitle>
         <CardDescription>{info.description}</CardDescription>
       </CardHeader>
       <CardContent>
         <div className="h-1 w-full bg-muted rounded-full overflow-hidden">
-          <div className="h-full w-0 bg-primary group-hover:w-full transition-all duration-500" />
+          <div className={cn(
+            "h-full w-0 bg-primary transition-all duration-500",
+            !disabled && "group-hover:w-full"
+            )} />   
         </div>
       </CardContent>
     </Card>

--- a/webapp/src/pages/GameModePage.tsx
+++ b/webapp/src/pages/GameModePage.tsx
@@ -5,8 +5,11 @@ import { ArrowLeft } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import type { GameMode } from '@/types'
 
-const modes: GameMode[] = ['pvp-local', 'pve', 'pvp-online']
-
+const modes: { mode: GameMode; disabled?: boolean }[] = [
+  { mode: 'pvp-local' },
+  { mode: 'pve' },
+  { mode: 'pvp-online', disabled: true },
+]
 export function GameModePage() {
   const { handleSelectMode } = useGameModeController()
   const navigate = useNavigate()
@@ -31,13 +34,14 @@ export function GameModePage() {
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {modes.map((mode) => (
-            <ModeCard
-              key={mode}
-              mode={mode}
-              onSelect={() => handleSelectMode(mode)}
-            />
-          ))}
+          {modes.map(({ mode, disabled }) => (
+        <ModeCard
+          key={mode}
+          mode={mode}
+          disabled={disabled}
+          onSelect={() => !disabled && handleSelectMode(mode)}
+        />
+      ))}
         </div>
       </div>
     </div>

--- a/webapp/src/test/GameModePage.test.tsx
+++ b/webapp/src/test/GameModePage.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { GameModePage } from '@/pages/GameModePage'
+
+const mockNavigate = vi.fn()
+const mockHandleSelectMode = vi.fn()
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}))
+vi.mock('@/controllers/useGameModeController', () => ({
+  useGameModeController: () => ({ handleSelectMode: mockHandleSelectMode }),
+}))
+
+describe('GameModePage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+    mockHandleSelectMode.mockClear()
+  })
+
+  it('renders the three mode cards', () => {
+    render(<GameModePage />)
+    expect(screen.getByText('Local Match')).toBeInTheDocument()
+    expect(screen.getByText('vs Computer')).toBeInTheDocument()
+    expect(screen.getByText('Online Match')).toBeInTheDocument()
+  })
+
+  it('navigates back on back button click', () => {
+    render(<GameModePage />)
+    fireEvent.click(screen.getByText('Back to Games'))
+    expect(mockNavigate).toHaveBeenCalledWith('/games')
+  })
+
+  it('calls handleSelectMode for pvp-local', () => {
+    render(<GameModePage />)
+    fireEvent.click(screen.getByText('Local Match'))
+    expect(mockHandleSelectMode).toHaveBeenCalledWith('pvp-local')
+  })
+
+  it('does not call handleSelectMode for pvp-online', () => {
+    render(<GameModePage />)
+    fireEvent.click(screen.getByText('Online Match'))
+    expect(mockHandleSelectMode).not.toHaveBeenCalled()
+  })
+})

--- a/webapp/src/test/ModeCard.test.tsx
+++ b/webapp/src/test/ModeCard.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ModeCard } from '@/components/ModeCard'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+describe('ModeCard', () => {
+  const onSelect = vi.fn()
+
+  beforeEach(() => onSelect.mockClear())
+
+  it('renders title and description for each mode', () => {
+    render(<ModeCard mode="pvp-local" onSelect={onSelect} />)
+    expect(screen.getByText('Local Match')).toBeInTheDocument()
+  })
+
+  it('calls onSelect when clicked', () => {
+    render(<ModeCard mode="pve" onSelect={onSelect} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onSelect on Enter key', () => {
+    render(<ModeCard mode="pve" onSelect={onSelect} />)
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onSelect on Space key', () => {
+    render(<ModeCard mode="pve" onSelect={onSelect} />)
+    fireEvent.keyDown(screen.getByRole('button'), { key: ' ' })
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  describe('when disabled', () => {
+    it('does not call onSelect when clicked', () => {
+      render(<ModeCard mode="pvp-online" onSelect={onSelect} disabled />)
+      fireEvent.click(screen.getByRole('button'))
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    it('does not call onSelect on Enter key', () => {
+      render(<ModeCard mode="pvp-online" onSelect={onSelect} disabled />)
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' })
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    it('has tabIndex -1', () => {
+      render(<ModeCard mode="pvp-online" onSelect={onSelect} disabled />)
+      expect(screen.getByRole('button')).toHaveAttribute('tabindex', '-1')
+    })
+
+    it('shows "Soon" label', () => {
+      render(<ModeCard mode="pvp-online" onSelect={onSelect} disabled />)
+      expect(screen.getByText('Soon')).toBeInTheDocument()
+    })
+
+    it('applies cursor-not-allowed class', () => {
+      render(<ModeCard mode="pvp-online" onSelect={onSelect} disabled />)
+    expect(screen.getByRole('button')).toHaveClass('cursor-not-allowed')    })
+  })
+})


### PR DESCRIPTION
## Disable pvp-online game mode

Closes #99

### Problem
The online game mode was selectable but not yet implemented, causing the application to crash when chosen.

### Solution
Disabled the `pvp-online` option until it is fully implemented.

### Changes
- Added "disabled" prop to ModeCard to block interaction 
- Added a guard in useGameModeController to prevent navigation when the mode is pvp-online
 