### PR TITLE
Bug: Statistics page always showed empty data for every account in local deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,5 +253,5 @@ cd gamey && cargo llvm-cov --lcov --output-path lcov.info
 | `DB_*` | — | Same MariaDB instance as users |
 | `JWT_SECRET` | — | Must match users service |
 | `RUST_INTERNAL_URL` | `http://gamey:4000` | Internal Docker hostname of the bot engine |
-| `USERS_PUBLIC_URL` | — | Users service URL via Nginx (for recording match results) |
+| `USERS_INTERNAL_URL` | `http://users:3000` | Internal Docker URL for the users service (for recording match results) |
 | `PUBLIC_URL` | — | Public base URL for the game service — used in startup logs |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       DB_PASSWORD: ${MARIADB_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
       PUBLIC_URL: ${VITE_GAME_API_URL}
-      USERS_PUBLIC_URL: ${VITE_USERS_API_URL}
+      USERS_INTERNAL_URL: http://users:3000
       RUST_INTERNAL_URL: http://gamey:4000
     depends_on:
       mariadb:
@@ -127,7 +127,6 @@ services:
       APP_ENV: ${APP_ENV:-production}
       WEBAPP_PORT: 3001
       PUBLIC_URL: ${VITE_INTEROP_API_URL}
-      # Must match the gamey service name on monitor-net
       RUST_INTERNAL_URL: http://gamey:4000
     depends_on:
       gamey:

--- a/game/src/services/GameService.ts
+++ b/game/src/services/GameService.ts
@@ -21,7 +21,7 @@ import type {
   BotLevel,
 } from '../types/game';
 
-const USERS_PUBLIC_URL = process.env.USERS_PUBLIC_URL || 'http://localhost:3000';
+const USERS_INTERNAL_URL = process.env.USERS_INTERNAL_URL || 'http://localhost:3000';
 
 export class GameService {
   private gameRepo: Repository<Game>;
@@ -374,7 +374,7 @@ export class GameService {
       (game.updatedAt.getTime() - game.createdAt.getTime()) / 1000
     );
 
-    await fetch(`${USERS_PUBLIC_URL}/api/stats/record`, {
+    await fetch(`${USERS_INTERNAL_URL}/api/stats/record`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
# Bug: Statistics page always showed empty data for every account in local and production deployments.

**Closes #159**

## Root cause

When a game ended, `GameService.recordMatch` called the users service using `USERS_PUBLIC_URL`, which was set to `${VITE_USERS_API_URL}` — a browser-facing URL (`http://api.localhost/users`). Since this call is made from inside the `game` Docker container, `api.localhost` doesn't resolve on the internal Docker network, causing the fetch to fail silently. Match records were never written to the database.

## Fix

- Renamed the env var from `USERS_PUBLIC_URL` to `USERS_INTERNAL_URL` to make its purpose explicit (server-to-server, not browser-facing).
- Set it to `http://users:3000` — the internal Docker service name — so the `game` container can reliably reach the `users` container on `monitor-net` in all environments.