### PR TITLE
 Replace Language Toggle Button And Fix Bugs

### DIFF
--- a/webapp/src/components/layout/AppNavbar.test.tsx
+++ b/webapp/src/components/layout/AppNavbar.test.tsx
@@ -63,15 +63,43 @@ describe('AppNavbar — branding', () => {
   })
 })
 
-describe('AppNavbar — language toggle button', () => {
-  it('renders the language toggle button', () => {
+describe('AppNavbar — language selector', () => {
+  it('renders the language select', () => {
     renderNavbar()
-    expect(screen.getByLabelText('Switch language')).toBeDefined()
+    expect(screen.getByRole('combobox')).toBeDefined()
   })
- 
-  it('language button is always visible (not gated behind user auth)', () => {
+
+  it('language selector is always visible (not gated behind user auth)', () => {
     renderNavbar({ user: null })
-    expect(screen.getByLabelText('Switch language')).toBeDefined()
+    expect(screen.getByRole('combobox')).toBeDefined()
+  })
+
+  it('shows available language options', () => {
+    renderNavbar()
+    expect(screen.getByRole('option', { name: 'ES' })).toBeDefined()
+    expect(screen.getByRole('option', { name: 'EN' })).toBeDefined()
+  })
+
+  it('calls setLanguage when selecting a new language', () => {
+    const setLanguage = vi.fn()
+
+    vi.mocked(useLanguage).mockReturnValue({
+      locale: 'en',
+      toggleLanguage: vi.fn(),
+      setLanguage,
+    } as any)
+
+    render(
+      <MemoryRouter>
+        <AppNavbar />
+      </MemoryRouter>
+    )
+
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'es' },
+    })
+
+    expect(setLanguage).toHaveBeenCalledWith('es')
   })
 })
 

--- a/webapp/src/components/layout/AppNavbar.tsx
+++ b/webapp/src/components/layout/AppNavbar.tsx
@@ -4,7 +4,8 @@ import { useAuth } from '@/contexts/AuthContext'
 import { useTheme } from '@/contexts/ThemeContext'
 import { useLanguage } from '@/i18n/LanguageContext'
 import { Button } from '@/components/ui/Button'
-import { Sun, Moon, LogOut, User, Hexagon, BarChart2, Trophy, Languages } from 'lucide-react'
+import { SUPPORTED_LOCALES, type SupportedLocale } from '@/i18n/i18n'
+import { Sun, Moon, LogOut, User, Hexagon, BarChart2, Trophy } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -14,12 +15,12 @@ import {
   DialogTitle,
 } from '@/components/ui/Dialog'
 import { useTranslation } from 'react-i18next'
-
+ 
 
 export function AppNavbar() {
   const { user, logout, isGuest } = useAuth()
   const { theme, toggleTheme } = useTheme()
-  const { toggleLanguage } = useLanguage()
+  const { locale, setLanguage } = useLanguage()
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [showLogoutDialog, setShowLogoutDialog] = useState(false)
@@ -38,16 +39,17 @@ export function AppNavbar() {
         </Link>
 
         <nav className="flex items-center gap-2">
-          {/* Language toggle */}
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={toggleLanguage}
-            aria-label={t('language.ariaLabel')}
-            title={t('language.switchTo')}
+         <select
+            value={locale}
+            onChange={(e) => setLanguage(e.target.value as SupportedLocale)}
+            className="bg-background text-foreground border border-border rounded-md px-2 py-1 text-sm appearance-none"
           >
-            <Languages className="h-5 w-5" />
-          </Button>
+            {SUPPORTED_LOCALES.map((lang) => (
+              <option key={lang} value={lang}>
+                {lang.toUpperCase()}
+              </option>
+            ))}
+          </select>
 
           {/* Theme toggle */}
           <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label={t('nav.toggleTheme')}>

--- a/webapp/src/i18n/es.ts
+++ b/webapp/src/i18n/es.ts
@@ -83,7 +83,7 @@ const es = {
 
   // ── Game Modes ────────────────────────────────────────────────────────────────
   gameModes: {
-    title: 'Juego Y',
+    title: 'Game Y',
     subtitle: 'Selecciona cómo quieres jugar',
     backToGames: 'Volver a juegos',
     pvpLocal: {
@@ -137,7 +137,7 @@ const es = {
   game: {
     loadingGame: 'Cargando partida...',
     gameNotFound: 'Partida no encontrada',
-    gameY: 'Juego Y',
+    gameY: 'Game Y',
     moves: 'Movimientos: {{count}}',
     surrender: 'Rendirse',
     playAgain: 'Jugar de nuevo',


### PR DESCRIPTION
 ## Summary

This PR replaces the previous language toggle button in the `AppNavbar` with a fully dynamic language selector (`<select>`), improving usability, scalability, and maintainability.

It also removes hardcoded language handling from the UI and relies entirely on the centralized i18n configuration.
Finally fixed some bugs related to translations.

---

## Changes

### Language Context Usage
- Replaced `toggleLanguage()` usage in the navbar
- Introduced `setLanguage(locale)` for explicit language selection
- Updated `useLanguage()` usage to include `locale`

---

### UI Changes (AppNavbar)

- Replaced icon button with a `<select>` dropdown
- Language options are now dynamically generated from `SUPPORTED_LOCALES`
- Added proper theming support (`bg-background`, `text-foreground`, `border-border`)
- Fixed dark mode readability issues in dropdown

