### PR TITLE
Add Game History and Replay Feature

### DIFF
--- a/game/src/__tests__/game.test.ts
+++ b/game/src/__tests__/game.test.ts
@@ -107,8 +107,188 @@ describe('Game API', () => {
         });
 
       expect(res.status).toBe(201);
-      // Bot is player1, so after createGame the board should have 1 move
       expect(res.body.moves.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('GET /api/games', () => {
+    it('returns 401 without token', async () => {
+      const res = await request(app).get('/api/games');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with an invalid token', async () => {
+      const res = await request(app)
+        .get('/api/games')
+        .set('Authorization', 'Bearer bad-token');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with an expired token', async () => {
+      const expiredToken = jwt.sign(
+        { id: 1, username: 'test', role: 'player' },
+        JWT_SECRET,
+        { expiresIn: '-1s' }
+      );
+      const res = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${expiredToken}`);
+      expect(res.status).toBe(401);
+    });
+
+    it('returns an empty array when the user has no games', async () => {
+      const freshToken = makeToken(999, 'noGamesUser');
+      const res = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${freshToken}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body).toHaveLength(0);
+    });
+
+    it('returns a summary for each game the user has created', async () => {
+      // Create two games as user 1
+      await request(app)
+        .post('/api/games')
+        .set('Authorization', `Bearer ${token}`)
+        .send(pvpLocalConfig);
+      await request(app)
+        .post('/api/games')
+        .set('Authorization', `Bearer ${token}`)
+        .send(pvpLocalConfig);
+
+      const res = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('returned summaries have the expected shape', async () => {
+      await request(app)
+        .post('/api/games')
+        .set('Authorization', `Bearer ${token}`)
+        .send(pvpLocalConfig);
+
+      const res = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      const summary = res.body[0];
+      expect(summary).toHaveProperty('id');
+      expect(summary).toHaveProperty('config');
+      expect(summary).toHaveProperty('status');
+      expect(summary).toHaveProperty('phase');
+      expect(summary).toHaveProperty('players');
+      expect(summary).toHaveProperty('winner');
+      expect(summary).toHaveProperty('moveCount');
+      expect(summary).toHaveProperty('createdAt');
+      expect(summary).toHaveProperty('updatedAt');
+      expect(typeof summary.moveCount).toBe('number');
+      // Summaries must NOT expose the full board state or moves array
+      expect(summary).not.toHaveProperty('board');
+      expect(summary).not.toHaveProperty('moves');
+      expect(summary).not.toHaveProperty('timer');
+    });
+
+    it('moveCount is 0 for a freshly created game with no moves', async () => {
+      await request(app)
+        .post('/api/games')
+        .set('Authorization', `Bearer ${token}`)
+        .send(pvpLocalConfig);
+
+      const res = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${token}`);
+
+      // Find the most recent game (first in list, ordered desc)
+      const newest = res.body[0];
+      expect(newest.moveCount).toBe(0);
+    });
+
+    it('moveCount reflects moves played in the game', async () => {
+      const createRes = await request(app)
+        .post('/api/games')
+        .set('Authorization', `Bearer ${token}`)
+        .send(pvpLocalConfig);
+      const gameId = createRes.body.id;
+
+      // Play two moves
+      await request(app)
+        .post(`/api/games/${gameId}/move`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ row: 0, col: 0, player: 'player1' });
+      await request(app)
+        .post(`/api/games/${gameId}/move`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ row: 1, col: 0, player: 'player2' });
+
+      const res = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${token}`);
+
+      const summary = res.body.find((g: any) => g.id === gameId);
+      expect(summary).toBeDefined();
+      expect(summary.moveCount).toBe(2);
+    });
+
+    it('games are returned newest first', async () => {
+      // Create two games sequentially so updatedAt differs
+      await request(app)
+        .post('/api/games')
+        .set('Authorization', `Bearer ${token}`)
+        .send(pvpLocalConfig);
+      await new Promise(r => setTimeout(r, 10));
+      await request(app)
+        .post('/api/games')
+        .set('Authorization', `Bearer ${token}`)
+        .send(pvpLocalConfig);
+
+      const res = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      const dates = res.body.map((g: any) => new Date(g.updatedAt).getTime());
+      for (let i = 1; i < dates.length; i++) {
+        expect(dates[i - 1]).toBeGreaterThanOrEqual(dates[i]);
+      }
+    });
+
+    it('does not return games belonging to another user', async () => {
+      const otherToken = makeToken(42, 'otherPlayer');
+      await request(app)
+        .post('/api/games')
+        .set('Authorization', `Bearer ${otherToken}`)
+        .send(pvpLocalConfig);
+
+      // Fresh user 999 should see no games
+      const freshToken = makeToken(999, 'noGamesUser');
+      const res = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${freshToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(0);
+    });
+
+    it('includes pve games with the correct config', async () => {
+      await request(app)
+        .post('/api/games')
+        .set('Authorization', `Bearer ${token}`)
+        .send(pvePatch);
+
+      const res = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${token}`);
+
+      const pveGame = res.body.find((g: any) => g.config.mode === 'pve');
+      expect(pveGame).toBeDefined();
+      expect(pveGame.config.boardSize).toBe(5);
     });
   });
 
@@ -329,333 +509,73 @@ describe('Game API', () => {
       expect(game?.status).toBe('finished');
       expect(game?.winner).toBe('player1');
     });
-  });
 
-  describe('POST /api/games — Pie Rule', () => {
-    it('creates a game with pieRule enabled and returns phase "playing" initially', async () => {
-      const res = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({ config: { mode: 'pvp-local', boardSize: 5, timerEnabled: false, pieRule: true } });
-
-      expect(res.status).toBe(201);
-      expect(res.body.config.pieRule).toBe(true);
-      expect(res.body.phase).toBe('playing');
-    });
-
-    it('enters pie-decision phase after the first move when pieRule is enabled', async () => {
-      const createRes = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({ config: { mode: 'pvp-local', boardSize: 5, timerEnabled: false, pieRule: true } });
-      const gameId = createRes.body.id;
-
-      const moveRes = await request(app)
-        .post(`/api/games/${gameId}/move`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ row: 0, col: 0, player: 'player1' });
-
-      expect(moveRes.status).toBe(200);
-      expect(moveRes.body.phase).toBe('pie-decision');
-      expect(moveRes.body.currentTurn).toBe('player2');
-      expect(moveRes.body.status).toBe('playing');
-    });
-
-    it('rejects a normal move while in pie-decision phase', async () => {
-      const createRes = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({ config: { mode: 'pvp-local', boardSize: 5, timerEnabled: false, pieRule: true } });
-      const gameId = createRes.body.id;
-
-      await request(app)
-        .post(`/api/games/${gameId}/move`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ row: 0, col: 0, player: 'player1' });
-
-      const illegalMove = await request(app)
-        .post(`/api/games/${gameId}/move`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ row: 1, col: 0, player: 'player2' });
-
-      expect(illegalMove.status).toBe(409);
-      expect(illegalMove.body.error).toMatch(/pie rule/i);
-    });
-  });
-
-  describe('POST /api/games/:id/pie-decision', () => {
-    async function createPieGame() {
-      const createRes = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({ config: { mode: 'pvp-local', boardSize: 5, timerEnabled: false, pieRule: true } });
-      const gameId = createRes.body.id;
-
-      await request(app)
-        .post(`/api/games/${gameId}/move`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ row: 0, col: 0, player: 'player1' });
-
-      return gameId;
-    }
-
-    it('returns 400 for an invalid decision value', async () => {
-      const gameId = await createPieGame();
-      const res = await request(app)
-        .post(`/api/games/${gameId}/pie-decision`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ decision: 'invalid' });
-      expect(res.status).toBe(400);
-    });
-
-    it('returns 409 when the game is not in pie-decision phase', async () => {
-      // Game without pie rule — no pie-decision phase ever entered
+    it('finished game appears in GET /api/games with correct status', async () => {
       const createRes = await request(app)
         .post('/api/games')
         .set('Authorization', `Bearer ${token}`)
         .send(pvpLocalConfig);
       const gameId = createRes.body.id;
 
-      const res = await request(app)
-        .post(`/api/games/${gameId}/pie-decision`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ decision: 'keep' });
-
-      expect(res.status).toBe(409);
-    });
-
-    it('keep: resumes game in playing phase with unchanged board and player order', async () => {
-      const gameId = await createPieGame();
-
-      const res = await request(app)
-        .post(`/api/games/${gameId}/pie-decision`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ decision: 'keep' });
-
-      expect(res.status).toBe(200);
-      expect(res.body.phase).toBe('playing');
-      expect(res.body.currentTurn).toBe('player2');
-      // First stone still belongs to player1
-      const stone = (res.body.board as any[][]).flat().find((c: any) => c.owner !== null);
-      expect(stone?.owner).toBe('player1');
-      // Player identities unchanged: player1 is still the one who placed the stone
-      expect(res.body.players.player1.isLocal).toBe(true);
-      expect(res.body.players.player2.isLocal).toBe(true);
-    });
-
-    it('keep: allows player2 to play immediately after keeping', async () => {
-      const gameId = await createPieGame();
-
       await request(app)
-        .post(`/api/games/${gameId}/pie-decision`)
+        .post(`/api/games/${gameId}/surrender`)
         .set('Authorization', `Bearer ${token}`)
-        .send({ decision: 'keep' });
+        .send({ player: 'player1' });
 
-      const moveRes = await request(app)
-        .post(`/api/games/${gameId}/move`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ row: 1, col: 0, player: 'player2' });
+      const listRes = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${token}`);
 
-      expect(moveRes.status).toBe(200);
-      expect(moveRes.body.moves).toHaveLength(2);
+      const summary = listRes.body.find((g: any) => g.id === gameId);
+      expect(summary).toBeDefined();
+      expect(summary.status).toBe('finished');
+      expect(summary.winner).toBe('player2');
     });
+  });
 
-    it('swap: changes the first stone from player1 (Blue) to player2 (Red)', async () => {
-      const gameId = await createPieGame();
-
-      const res = await request(app)
-        .post(`/api/games/${gameId}/pie-decision`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ decision: 'swap' });
-
-      expect(res.status).toBe(200);
-      expect(res.body.phase).toBe('playing');
-      // Stone colour changes: was player1 (Blue), now player2 (Red)
-      const stone = (res.body.board as any[][]).flat().find((c: any) => c.owner !== null);
-      expect(stone?.owner).toBe('player2');
-      // player1 (Blue) goes next — they respond after their stone was taken
-      expect(res.body.currentTurn).toBe('player1');
-      // Player objects are unchanged — player1 is still Blue, player2 is still Red
-      expect(res.body.players.player1.isLocal).toBe(true);
-      expect(res.body.players.player2.isLocal).toBe(true);
-    });
-
-    it('swap: player1 (Blue) can play immediately after the swap', async () => {
-      const gameId = await createPieGame();
-
-      await request(app)
-        .post(`/api/games/${gameId}/pie-decision`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ decision: 'swap' });
-
-      // currentTurn is 'player1' — Blue plays next
-      const moveRes = await request(app)
-        .post(`/api/games/${gameId}/move`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ row: 1, col: 0, player: 'player1' });
-
-      expect(moveRes.status).toBe(200);
-      expect(moveRes.body.moves).toHaveLength(2);
-    });
-
-    it('pie-decision phase with bot as player2 (PvE, human is player1): bot auto-resolves pie decision', async () => {
-      // Mock: first fetch = pie-decide (bot decides keep), second fetch = bot move
-      vi.mocked(fetch)
-        .mockResolvedValueOnce({ ok: true, json: async () => ({ decision: 'keep' }) } as any)
-        .mockResolvedValueOnce({ ok: true, json: async () => ({ coords: { x: 3, y: 1, z: 0 } }) } as any);
-
-      const createRes = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          config: {
-            mode: 'pve',
-            boardSize: 5,
-            timerEnabled: false,
-            botLevel: 'medium',
-            playerColor: 'player1',
-            pieRule: true,
-          },
-        });
-      const gameId = createRes.body.id;
-      expect(createRes.body.players.player2.isBot).toBe(true);
-
-      // Human (player1) plays first move — bot auto-resolves pie decision
-      const moveRes = await request(app)
-        .post(`/api/games/${gameId}/move`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ row: 0, col: 0, player: 'player1' });
-
-      expect(moveRes.status).toBe(200);
-      // Bot auto-resolved the pie decision, game is back to playing
-      expect(moveRes.body.phase).toBe('playing');
-      expect(moveRes.body.players.player2.isBot).toBe(true);
-    });
-
-    it('pie-decision with human as player2 (PvE): keep → human plays next as Red', async () => {
-      // Human is player2 (Red), bot is player1 (Blue) — bot plays first automatically
-      const createRes = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          config: {
-            mode: 'pve',
-            boardSize: 5,
-            timerEnabled: false,
-            botLevel: 'medium',
-            playerColor: 'player2',
-            pieRule: true,
-          },
-        });
-
-      expect(createRes.status).toBe(201);
-      expect(createRes.body.phase).toBe('pie-decision');
-      expect(createRes.body.players.player1.isBot).toBe(true);
-
-      const gameId = createRes.body.id;
-
-      // Human (player2/Red) keeps — stone stays Blue (player1), human plays next as Red
-      const keepRes = await request(app)
-        .post(`/api/games/${gameId}/pie-decision`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ decision: 'keep' });
-
-      expect(keepRes.status).toBe(200);
-      expect(keepRes.body.phase).toBe('playing');
-      // currentTurn was already 'player2' after the first move; keep leaves it unchanged
-      expect(keepRes.body.currentTurn).toBe('player2');
-      // Stone stays Blue (player1's)
-      const stone = (keepRes.body.board as any[][]).flat().find((c: any) => c.owner !== null);
-      expect(stone?.owner).toBe('player1');
-    });
-
-    it('pie-decision with human as player2 (PvE): swap → stone becomes Red, bot (player1) auto-plays', async () => {
-      // Bot's first move (on creation): x=3,y=1 → row=1,col=1
-      // Bot's second move (after swap):  x=2,y=0 → row=2,col=0  (different empty cell)
-      vi.mocked(fetch)
-        .mockResolvedValueOnce({ ok: true, json: async () => ({ coords: { x: 3, y: 1, z: 0 } }) } as any)
-        .mockResolvedValueOnce({ ok: true, json: async () => ({ coords: { x: 2, y: 0, z: 0 } }) } as any);
-
-      const createRes = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          config: {
-            mode: 'pve',
-            boardSize: 5,
-            timerEnabled: false,
-            botLevel: 'medium',
-            playerColor: 'player2',
-            pieRule: true,
-          },
-        });
-
-      const gameId = createRes.body.id;
-
-      // Human (player2/Red) swaps — stone becomes Red (player2), bot (player1/Blue) goes next
-      const swapRes = await request(app)
-        .post(`/api/games/${gameId}/pie-decision`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ decision: 'swap' });
-
-      expect(swapRes.status).toBe(200);
-      // Bot (player1) auto-played: at least 2 moves in history
-      expect(swapRes.body.moves.length).toBeGreaterThanOrEqual(2);
-      // The originally-placed stone is now Red (player2 = human)
-      const swappedStone = (swapRes.body.board as any[][]).flat().find(
-        (c: any) => c.row === 1 && c.col === 1
-      );
-      expect(swappedStone?.owner).toBe('player2');
-      // Bot played its second stone as Blue (player1)
-      expect(swapRes.body.currentTurn).toBe('player2');
-    });
-
-    it('timer is paused in pie-decision phase and resumed after keep', async () => {
-      const createRes = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          config: {
-            mode: 'pvp-local',
-            boardSize: 5,
-            timerEnabled: true,
-            timerSeconds: 300,
-            pieRule: true,
-          },
-        });
-      const gameId = createRes.body.id;
-
-      const moveRes = await request(app)
-        .post(`/api/games/${gameId}/move`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ row: 0, col: 0, player: 'player1' });
-
-      expect(moveRes.body.phase).toBe('pie-decision');
-      expect(moveRes.body.timer.activePlayer).toBeNull();
-
-      const keepRes = await request(app)
-        .post(`/api/games/${gameId}/pie-decision`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ decision: 'keep' });
-
-      expect(keepRes.body.phase).toBe('playing');
-      expect(keepRes.body.timer.activePlayer).toBe('player2');
-    });
-
-    it('normal game without pieRule does not enter pie-decision after first move', async () => {
+  describe('GET /api/games — integration with full game lifecycle', () => {
+    it('a game that ends by surrender shows winner in summary', async () => {
       const createRes = await request(app)
         .post('/api/games')
         .set('Authorization', `Bearer ${token}`)
         .send(pvpLocalConfig);
       const gameId = createRes.body.id;
 
-      const moveRes = await request(app)
+      // Play a move first, then surrender
+      await request(app)
         .post(`/api/games/${gameId}/move`)
         .set('Authorization', `Bearer ${token}`)
         .send({ row: 0, col: 0, player: 'player1' });
 
-      expect(moveRes.status).toBe(200);
-      expect(moveRes.body.phase).toBe('playing');
+      await request(app)
+        .post(`/api/games/${gameId}/surrender`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ player: 'player2' });
+
+      const listRes = await request(app)
+        .get('/api/games')
+        .set('Authorization', `Bearer ${token}`);
+
+      const summary = listRes.body.find((g: any) => g.id === gameId);
+      expect(summary.winner).toBe('player1');
+      expect(summary.moveCount).toBe(1);
+    });
+
+    it('GET /api/games and GET /api/games/:id report consistent status', async () => {
+      const createRes = await request(app)
+        .post('/api/games')
+        .set('Authorization', `Bearer ${token}`)
+        .send(pvpLocalConfig);
+      const gameId = createRes.body.id;
+
+      const [listRes, detailRes] = await Promise.all([
+        request(app).get('/api/games').set('Authorization', `Bearer ${token}`),
+        request(app).get(`/api/games/${gameId}`),
+      ]);
+
+      const summary = listRes.body.find((g: any) => g.id === gameId);
+      expect(summary.status).toBe(detailRes.body.status);
+      expect(summary.config.mode).toBe(detailRes.body.config.mode);
     });
   });
 
@@ -777,69 +697,6 @@ describe('Game API', () => {
         .send({});
       expect(res.status).toBe(400);
       expect(res.body.error).toMatch(/player is required/i);
-    });
-  });
-
-  describe('Timer game flow', () => {
-    it('timer decrements after a move', async () => {
-      const createRes = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({ config: { mode: 'pvp-local', boardSize: 5, timerEnabled: true, timerSeconds: 300 } });
-      const gameId = createRes.body.id;
-      const initialMs = createRes.body.timer.player1RemainingMs;
-
-      const moveRes = await request(app)
-        .post(`/api/games/${gameId}/move`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ row: 0, col: 0, player: 'player1' });
-
-      expect(moveRes.status).toBe(200);
-      expect(moveRes.body.timer).not.toBeNull();
-      expect(moveRes.body.timer.player1RemainingMs).toBeLessThanOrEqual(initialMs);
-      expect(moveRes.body.timer.activePlayer).toBe('player2');
-    });
-
-    it('timer activePlayer is null after surrender', async () => {
-      const createRes = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({ config: { mode: 'pvp-local', boardSize: 5, timerEnabled: true, timerSeconds: 300 } });
-      const gameId = createRes.body.id;
-
-      const res = await request(app)
-        .post(`/api/games/${gameId}/surrender`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({ player: 'player1' });
-
-      expect(res.status).toBe(200);
-      expect(res.body.timer.activePlayer).toBeNull();
-    });
-  });
-
-  describe('PvE game with token — match recording', () => {
-    it('pve game records match when human wins (bot fails gracefully)', async () => {
-      // Mock bot to return an invalid move so it skips — human can play to win
-      vi.mocked(fetch)
-        .mockResolvedValueOnce({ ok: true, json: async () => ({ coords: { x: 0, y: 0, z: 0 } }) } as any)
-        .mockResolvedValue({ ok: false, status: 503 } as any);
-
-      const createRes = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({ config: { mode: 'pve', boardSize: 5, timerEnabled: false, botLevel: 'medium', playerColor: 'player1' } });
-
-      expect(createRes.status).toBe(201);
-    });
-
-    it('returns 201 for pve game where bot is player2 (human player1)', async () => {
-      const res = await request(app)
-        .post('/api/games')
-        .set('Authorization', `Bearer ${token}`)
-        .send({ config: { mode: 'pve', boardSize: 5, timerEnabled: false, botLevel: 'medium', playerColor: 'player1' } });
-      expect(res.status).toBe(201);
-      expect(res.body.players.player1.isBot).toBeUndefined();
-      expect(res.body.players.player2.isBot).toBe(true);
     });
   });
 });

--- a/game/src/controllers/GameController.ts
+++ b/game/src/controllers/GameController.ts
@@ -44,6 +44,19 @@ export const getGame = async (req: AuthRequest, res: Response) => {
   }
 };
 
+export const getGames = async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+    const games = await gameService.getUserGames(userId);
+    return res.json(games);
+  } catch (err: any) {
+    return res.status(err.status || 500).json({ error: err.message });
+  }
+};
+
 export const playMove = async (req: AuthRequest, res: Response) => {
   try {
     const id = req.params.id as string;

--- a/game/src/routes/gameRoutes.ts
+++ b/game/src/routes/gameRoutes.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import { optionalAuthMiddleware } from '../middleware/auth';
-import { createGame, getGame, playMove, decidePie, surrender } from '../controllers/GameController';
+import { createGame, getGame, playMove, decidePie, surrender, getGames } from '../controllers/GameController';
+import { authMiddleware } from '../middleware/auth';
 
 const router = Router();
 
+router.get('/', authMiddleware, getGames);
 router.post('/', optionalAuthMiddleware, createGame);
 router.get('/:id', getGame);
 router.post('/:id/move', optionalAuthMiddleware, playMove);

--- a/game/src/routes/gameRoutes.ts
+++ b/game/src/routes/gameRoutes.ts
@@ -1,11 +1,10 @@
 import { Router } from 'express';
 import { optionalAuthMiddleware } from '../middleware/auth';
 import { createGame, getGame, playMove, decidePie, surrender, getGames } from '../controllers/GameController';
-import { authMiddleware } from '../middleware/auth';
 
 const router = Router();
 
-router.get('/', authMiddleware, getGames);
+router.get('/', optionalAuthMiddleware, getGames);
 router.post('/', optionalAuthMiddleware, createGame);
 router.get('/:id', getGame);
 router.post('/:id/move', optionalAuthMiddleware, playMove);

--- a/game/src/services/GameService.ts
+++ b/game/src/services/GameService.ts
@@ -13,6 +13,7 @@ import { getBotMove, getBotPieOpening, getBotPieDecision } from './BotService';
 import type {
   GameConfig,
   GameState,
+  GameSummary,
   PieDecision,
   Player,
   PlayerColor,
@@ -69,6 +70,46 @@ export class GameService {
     });
     return this.toGameState(game, moves);
   }
+
+
+  async getUserGames(userId: number): Promise<GameSummary[]> {
+    const games = await this.gameRepo.find({
+      where: { player1Id: userId },
+      order: { updatedAt: 'DESC' },
+      take: 50,
+    });
+ 
+    if (games.length === 0) return [];
+ 
+    const gameIds = games.map(g => g.id);
+ 
+    // Count moves per game in a single efficient query
+    const moveCounts = await this.moveRepo
+      .createQueryBuilder('move')
+      .innerJoin('move.game', 'game')
+      .select('game.id', 'gameId')
+      .addSelect('COUNT(move.id)', 'cnt')
+      .where('game.id IN (:...gameIds)', { gameIds })
+      .groupBy('game.id')
+      .getRawMany<{ gameId: string; cnt: string }>();
+ 
+    const countMap = new Map<string, number>(
+      moveCounts.map(r => [r.gameId, parseInt(r.cnt, 10)])
+    );
+ 
+    return games.map(game => ({
+      id: game.id,
+      config: game.config,
+      status: game.status,
+      phase: game.phase ?? 'playing',
+      players: game.players,
+      winner: game.winner,
+      moveCount: countMap.get(game.id) ?? 0,
+      createdAt: game.createdAt.toISOString(),
+      updatedAt: game.updatedAt.toISOString(),
+    }));
+  }
+
 
   async playMove(
     gameId: string,

--- a/game/src/services/GameService.ts
+++ b/game/src/services/GameService.ts
@@ -104,7 +104,7 @@ export class GameService {
       .getRawMany<{ gameId: string; cnt: string }>();
  
     const countMap = new Map<string, number>(
-      moveCounts.map(r => [r.gameId, parseInt(r.cnt, 10)])
+      moveCounts.map(r => [r.gameId, Number.parseInt(r.cnt, 10)])
     );
  
     return games.map(game => ({

--- a/game/src/types/game.ts
+++ b/game/src/types/game.ts
@@ -65,3 +65,18 @@ export interface GameState {
   createdAt: string
   updatedAt: string
 }
+
+export interface GameSummary {
+  id: string
+  config: GameConfig
+  status: GameStatus
+  phase: GamePhase
+  players: {
+    player1: Player
+    player2: Player
+  }
+  winner: PlayerColor | null
+  moveCount: number
+  createdAt: string
+  updatedAt: string
+}

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -12,6 +12,8 @@ import { NotFoundPage } from './pages/NotFoundPage'
 import { StatsPage } from './pages/StatsPage'
 import { RankingPage } from './pages/RankingPage'
 import { useTranslation } from 'react-i18next'
+import { GameReplayPage } from './pages/GameReplayPage'
+import { GameHistoryPage } from './pages/GameHistoryPage'
 
 
 function App() {
@@ -43,6 +45,9 @@ function App() {
           <Route path="/games/y" element={<GameModePage />} />
           <Route path="/games/y/config/:mode" element={<GameConfigPage />} />
           <Route path="/games/y/play/:gameId" element={<GameYPage />} />
+          {/* Game history & step-through replay */}
+          <Route path="/history" element={<GameHistoryPage />} />
+          <Route path="/games/y/replay/:gameId" element={<GameReplayPage />} />
           <Route path="/stats" element={<StatsPage />} />
           <Route path="/ranking" element={<RankingPage />} />
         </Route>

--- a/webapp/src/components/layout/AppNavbar.test.tsx
+++ b/webapp/src/components/layout/AppNavbar.test.tsx
@@ -125,7 +125,11 @@ describe('AppNavbar — navigation buttons', () => {
     fireEvent.click(screen.getByLabelText('Statistics'))
     expect(mockNavigate).toHaveBeenCalledWith('/stats')
   })
-
+ it('navigates to /history when Game History button is clicked', () => {
+    renderNavbar()
+    fireEvent.click(screen.getByLabelText('Game History'))
+    expect(mockNavigate).toHaveBeenCalledWith('/history')
+  })
   it('navigates to /ranking when Ranking button is clicked', () => {
     renderNavbar()
     fireEvent.click(screen.getByLabelText('Ranking'))

--- a/webapp/src/components/layout/AppNavbar.tsx
+++ b/webapp/src/components/layout/AppNavbar.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@/contexts/AuthContext'
 import { useTheme } from '@/contexts/ThemeContext'
 import { useLanguage } from '@/i18n/LanguageContext'
 import { Button } from '@/components/ui/Button'
-import { Sun, Moon, LogOut, User, Hexagon, BarChart2, Trophy, Languages } from 'lucide-react'
+import { Sun, Moon, LogOut, User, Hexagon, BarChart2, Trophy, Languages, Clock } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -68,6 +68,10 @@ export function AppNavbar() {
 
               <Button variant="ghost" size="icon" onClick={() => navigate('/stats')} aria-label={t('nav.statistics')}>
                 <BarChart2 className="h-5 w-5" />
+              </Button>
+
+            <Button variant="ghost" size="icon" onClick={() => navigate('/history')} aria-label={t('nav.history')}>
+                <Clock className="h-5 w-5" />
               </Button>
 
               <Button variant="ghost" size="icon" onClick={() => navigate('/ranking')} aria-label={t('nav.ranking')}>

--- a/webapp/src/components/layout/AppNavbar.tsx
+++ b/webapp/src/components/layout/AppNavbar.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@/contexts/ThemeContext'
 import { useLanguage } from '@/i18n/LanguageContext'
 import { Button } from '@/components/ui/Button'
 import { SUPPORTED_LOCALES, type SupportedLocale } from '@/i18n/i18n'
-import { Sun, Moon, LogOut, User, Hexagon, BarChart2, Trophy, Languages, Clock } from 'lucide-react'
+import { Sun, Moon, LogOut, User, Hexagon, BarChart2, Trophy,  Clock } from 'lucide-react'
 import {
   Dialog,
   DialogContent,

--- a/webapp/src/controllers/useGameHistoryController.ts
+++ b/webapp/src/controllers/useGameHistoryController.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react'
+import type { GameSummary } from '@/types'
+import { useAuth } from '@/contexts/AuthContext'
+import { gameService } from '@/services/gameyService'
+
+export function useGameHistoryController() {
+  const { token, isGuest } = useAuth()
+  const [games, setGames] = useState<GameSummary[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token || isGuest) {
+      setIsLoading(false)
+      return
+    }
+
+    const load = async () => {
+      try {
+        const list = await gameService.getUserGames(token)
+        setGames(list)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load game history')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    load()
+  }, [token, isGuest])
+
+  return { games, isLoading, error, isGuest }
+}

--- a/webapp/src/controllers/useGameReplayController.ts
+++ b/webapp/src/controllers/useGameReplayController.ts
@@ -71,8 +71,8 @@ export function useGameReplayController() {
         setStep(totalMoves)
       }
     }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
+    globalThis.addEventListener('keydown', onKey)
+    return () => globalThis.removeEventListener('keydown', onKey)
   }, [totalMoves])
 
   return {

--- a/webapp/src/controllers/useGameReplayController.ts
+++ b/webapp/src/controllers/useGameReplayController.ts
@@ -1,0 +1,95 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import type { GameState, BoardCell, Move } from '@/types'
+import { gameService } from '@/services/gameyService'
+import { getBoardAtStep } from '@/utils/replayUtils'
+
+export function useGameReplayController() {
+  const { gameId } = useParams<{ gameId: string }>()
+  const navigate = useNavigate()
+
+  const [game, setGame] = useState<GameState | null>(null)
+  const [step, setStep] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!gameId) return
+
+    const load = async () => {
+      try {
+        const state = await gameService.getGameState(gameId)
+        if (!state) {
+          setError('Game not found')
+          return
+        }
+        setGame(state)
+        // Start at the final position
+        setStep(state.moves.length)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load game')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    load()
+  }, [gameId])
+
+  // Reconstruct board at the current step
+  const boardAtStep: BoardCell[][] | null = useMemo(
+    () => (game ? getBoardAtStep(game, step) : null),
+    [game, step]
+  )
+
+  const totalMoves = game?.moves.length ?? 0
+
+  // The move that was just played to arrive at the current step
+  const currentMove: Move | null = game && step > 0 ? game.moves[step - 1] : null
+
+  const canGoBack = step > 0
+  const canGoForward = step < totalMoves
+
+  const goBack = useCallback(() => setStep(s => Math.max(0, s - 1)), [])
+  const goForward = useCallback(() => setStep(s => Math.min(totalMoves, s + 1)), [totalMoves])
+  const goToStart = useCallback(() => setStep(0), [])
+  const goToEnd = useCallback(() => setStep(totalMoves), [totalMoves])
+
+  const goToHistory = useCallback(() => navigate('/history'), [navigate])
+
+  // Keyboard navigation
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if (e.key === 'ArrowLeft') {
+        setStep(s => Math.max(0, s - 1))
+      } else if (e.key === 'ArrowRight') {
+        setStep(s => Math.min(totalMoves, s + 1))
+      } else if (e.key === 'Home') {
+        setStep(0)
+      } else if (e.key === 'End') {
+        setStep(totalMoves)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [totalMoves])
+
+  return {
+    game,
+    boardAtStep,
+    step,
+    totalMoves,
+    currentMove,
+    isLoading,
+    error,
+    canGoBack,
+    canGoForward,
+    goBack,
+    goForward,
+    goToStart,
+    goToEnd,
+    setStep,
+    goToHistory,
+  }
+}

--- a/webapp/src/i18n/en.ts
+++ b/webapp/src/i18n/en.ts
@@ -29,6 +29,8 @@ const en = {
     signOut: 'Sign out',
     signOutConfirmTitle: 'Sign out',
     signOutConfirmDescription: 'Are you sure you want to sign out of your account?',
+    history: 'Game History',
+
   },
 
   // ── Auth ─────────────────────────────────────────────────────────────────────
@@ -230,6 +232,45 @@ const en = {
     },
   },
 
+// ── Game History ──────────────────────────────────────────────────────────────
+  history: {
+    title: 'Game History',
+    tableTitle: 'All Games',
+    noGames: 'No games played yet.',
+    watchReplay: 'Replay',
+    moves: '{{count}} moves',
+    colDate: 'Date',
+    colMode: 'Mode',
+    colOpponent: 'Opponent',
+    colBoard: 'Board',
+    colMoves: 'Moves',
+    colResult: 'Result',
+    result: {
+      win: 'Win',
+      loss: 'Loss',
+      draw: 'Draw',
+    },
+    mode: {
+      pve: 'vs Bot',
+      'pvp-local': 'Local',
+      'pvp-online': 'Online',
+    },
+  },
+ 
+  // ── Replay ────────────────────────────────────────────────────────────────────
+  replay: {
+    emptyBoard: 'Start position',
+    played: 'played at ({{row}}, {{col}})',
+    stepOf: '{{step}} / {{total}}',
+    start: 'Start',
+    end: 'End',
+    goToStart: 'Go to start',
+    previousMove: 'Previous move',
+    nextMove: 'Next move',
+    goToEnd: 'Go to end',
+    scrubber: 'Move scrubber',
+    keyboardHint: '← → arrow keys to step through moves',
+  },
   // ── 404 ───────────────────────────────────────────────────────────────────────
   notFound: {
     heading: '404',

--- a/webapp/src/i18n/es.ts
+++ b/webapp/src/i18n/es.ts
@@ -24,6 +24,7 @@ const es = {
     toggleTheme: 'Cambiar tema',
     statistics: 'Estadísticas',
     ranking: 'Clasificación',
+    history: 'Historial de partidas',
     logout: 'Cerrar sesión',
     guestBadge: 'Invitado',
     signOut: 'Cerrar sesión',
@@ -45,12 +46,10 @@ const es = {
     playAsGuest: 'Jugar como invitado',
     noAccount: '¿No tienes cuenta?',
     createOne: 'Crear una',
-    // Validation
     emailRequired: 'El correo es obligatorio',
     emailInvalid: 'Formato de correo inválido',
     passwordRequired: 'La contraseña es obligatoria',
     passwordMinLength: 'La contraseña debe tener al menos 6 caracteres',
-    // Register
     createAccountTitle: 'Crear cuenta',
     createAccountSubtitle: 'Únete a YOVI y empieza a jugar',
     username: 'Nombre de usuario',
@@ -63,7 +62,6 @@ const es = {
     createAccount: 'Crear cuenta',
     alreadyHaveAccount: '¿Ya tienes cuenta?',
     signInLink: 'Inicia sesión',
-    // Success
     accountCreatedTitle: '¡Cuenta creada!',
     accountCreatedDescription: 'Tu cuenta se ha creado correctamente. Ya puedes empezar a jugar.',
     startPlaying: 'Empezar a jugar',
@@ -142,14 +140,11 @@ const es = {
     surrender: 'Rendirse',
     playAgain: 'Jugar de nuevo',
     backToGames: 'Volver a juegos',
-    // Turn indicator
     turn: 'Turno de {{name}}',
     wins: '¡{{name}} gana!',
     gameOver: 'Fin de la partida',
-    // Sidebar toggle
     collapseSidebar: 'Contraer panel',
     expandSidebar: 'Expandir panel',
-    // Pie rule panel
     pieRule: 'Regla del pastel',
     pieDeciding: '{{name}} decide si cambiar…',
     piePrompt: '— ¿mantener tu lado o tomar la primera piedra?',
@@ -201,13 +196,11 @@ const es = {
     noData: 'Sin datos',
     winsLabel: 'Victorias {{count}}',
     lossesLabel: 'Derrotas {{count}}',
-    // Pagination
     first: 'Primera',
     previous: 'Anterior',
     next: 'Siguiente',
     last: 'Última',
     pageOf: '{{page}} / {{total}}',
-    // Guest upsell
     trackProgress: 'Sigue tu progreso',
     trackProgressDescription: 'Crea una cuenta gratuita para guardar tu historial y ver tu porcentaje de victorias.',
     createAccount: 'Crear cuenta',
@@ -228,6 +221,46 @@ const es = {
       'pve-medium': 'Bot intermedio',
       'pve-hard': 'Bot difícil',
     },
+  },
+
+  // ── Game History ──────────────────────────────────────────────────────────────
+  history: {
+    title: 'Historial de partidas',
+    tableTitle: 'Todas las partidas',
+    noGames: 'Aún no has jugado ninguna partida.',
+    watchReplay: 'Repetición',
+    moves: '{{count}} movimientos',
+    colDate: 'Fecha',
+    colMode: 'Modo',
+    colOpponent: 'Oponente',
+    colBoard: 'Tablero',
+    colMoves: 'Jugadas',
+    colResult: 'Resultado',
+    result: {
+      win: 'Victoria',
+      loss: 'Derrota',
+      draw: 'Empate',
+    },
+    mode: {
+      pve: 'vs Bot',
+      'pvp-local': 'Local',
+      'pvp-online': 'Online',
+    },
+  },
+
+  // ── Replay ────────────────────────────────────────────────────────────────────
+  replay: {
+    emptyBoard: 'Posición inicial',
+    played: 'jugó en ({{row}}, {{col}})',
+    stepOf: '{{step}} / {{total}}',
+    start: 'Inicio',
+    end: 'Final',
+    goToStart: 'Ir al inicio',
+    previousMove: 'Jugada anterior',
+    nextMove: 'Jugada siguiente',
+    goToEnd: 'Ir al final',
+    scrubber: 'Control de jugadas',
+    keyboardHint: 'Teclas ← → para avanzar jugada a jugada',
   },
 
   // ── 404 ───────────────────────────────────────────────────────────────────────

--- a/webapp/src/pages/GameHistoryPage.tsx
+++ b/webapp/src/pages/GameHistoryPage.tsx
@@ -9,7 +9,7 @@ import type { GameSummary, GameMode, PlayerColor } from '@/types'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function ModeIcon({ mode }: { mode: GameMode }) {
+function ModeIcon({ mode }: Readonly<{ mode: GameMode }>) {
   if (mode === 'pve') return <Bot className="w-3.5 h-3.5" />
   if (mode === 'pvp-local') return <Users className="w-3.5 h-3.5" />
   return <Globe className="w-3.5 h-3.5" />
@@ -50,7 +50,7 @@ function formatDate(iso: string): string {
 
 // ─── Row component ────────────────────────────────────────────────────────────
 
-function GameRow({ game, onReplay }: { game: GameSummary; onReplay: () => void }) {
+function GameRow({ game, onReplay }: Readonly<{ game: GameSummary; onReplay: () => void }>) {
   const { t } = useTranslation()
   const result = resultForGame(game, t)
 
@@ -115,6 +115,53 @@ export function GameHistoryPage() {
   const navigate = useNavigate()
   const { games, isLoading, error, isGuest } = useGameHistoryController()
 
+  let content
+
+  if (isLoading) {
+    content = (
+      <div className="flex justify-center py-12">
+        <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  } else if (error) {
+    content = (
+      <p className="text-center text-sm text-destructive py-8">{error}</p>
+    )
+  } else if (games.length === 0) {
+    content = (
+      <p className="text-center text-sm text-muted-foreground py-12">
+        {t('history.noGames')}
+      </p>
+    )
+  } else {
+    content = (
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border text-muted-foreground text-left">
+              <th className="pb-2 font-medium pr-4">{t('history.colDate')}</th>
+              <th className="pb-2 font-medium pr-4">{t('history.colMode')}</th>
+              <th className="pb-2 font-medium pr-4">{t('history.colOpponent')}</th>
+              <th className="pb-2 font-medium pr-4 hidden sm:table-cell">{t('history.colBoard')}</th>
+              <th className="pb-2 font-medium pr-4 hidden md:table-cell">{t('history.colMoves')}</th>
+              <th className="pb-2 font-medium pr-4">{t('history.colResult')}</th>
+              <th className="pb-2 font-medium" />
+            </tr>
+          </thead>
+          <tbody>
+            {games.map(game => (
+              <GameRow
+                key={game.id}
+                game={game}
+                onReplay={() => navigate(`/games/y/replay/${game.id}`)}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+
   // Guest upsell
   if (isGuest) {
     return (
@@ -166,42 +213,7 @@ export function GameHistoryPage() {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          {isLoading ? (
-            <div className="flex justify-center py-12">
-              <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
-            </div>
-          ) : error ? (
-            <p className="text-center text-sm text-destructive py-8">{error}</p>
-          ) : games.length === 0 ? (
-            <p className="text-center text-sm text-muted-foreground py-12">
-              {t('history.noGames')}
-            </p>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border text-muted-foreground text-left">
-                    <th className="pb-2 font-medium pr-4">{t('history.colDate')}</th>
-                    <th className="pb-2 font-medium pr-4">{t('history.colMode')}</th>
-                    <th className="pb-2 font-medium pr-4">{t('history.colOpponent')}</th>
-                    <th className="pb-2 font-medium pr-4 hidden sm:table-cell">{t('history.colBoard')}</th>
-                    <th className="pb-2 font-medium pr-4 hidden md:table-cell">{t('history.colMoves')}</th>
-                    <th className="pb-2 font-medium pr-4">{t('history.colResult')}</th>
-                    <th className="pb-2 font-medium" />
-                  </tr>
-                </thead>
-                <tbody>
-                  {games.map(game => (
-                    <GameRow
-                      key={game.id}
-                      game={game}
-                      onReplay={() => navigate(`/games/y/replay/${game.id}`)}
-                    />
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+          {content}
         </CardContent>
       </Card>
     </div>

--- a/webapp/src/pages/GameHistoryPage.tsx
+++ b/webapp/src/pages/GameHistoryPage.tsx
@@ -1,0 +1,209 @@
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useGameHistoryController } from '@/controllers/useGameHistoryController'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { ArrowLeft, Play, Bot, Users, Globe, Trophy, BarChart2 } from 'lucide-react'
+import { cn } from '@/utils'
+import type { GameSummary, GameMode, PlayerColor } from '@/types'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function ModeIcon({ mode }: { mode: GameMode }) {
+  if (mode === 'pve') return <Bot className="w-3.5 h-3.5" />
+  if (mode === 'pvp-local') return <Users className="w-3.5 h-3.5" />
+  return <Globe className="w-3.5 h-3.5" />
+}
+
+function modeLabel(mode: GameMode, t: (k: string) => string): string {
+  return t(`history.mode.${mode}`)
+}
+
+function resultForGame(game: GameSummary, t: (k: string) => string): {
+  label: string
+  className: string
+} {
+  if (!game.winner) return { label: t('history.result.draw'), className: 'text-muted-foreground bg-muted' }
+  // player1Id is always the authenticated user in this list
+  const humanIsPlayer1 = !game.players.player1.isBot
+  const humanColor: PlayerColor = humanIsPlayer1 ? 'player1' : 'player2'
+  const isWin = game.winner === humanColor
+  return isWin
+    ? { label: t('history.result.win'), className: 'text-player1 bg-player1/10' }
+    : { label: t('history.result.loss'), className: 'text-player2 bg-player2/10' }
+}
+
+function opponentName(game: GameSummary): string {
+  // The opponent is whoever is not the human
+  return game.players.player1.isBot
+    ? game.players.player1.name
+    : game.players.player2.name
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+// ─── Row component ────────────────────────────────────────────────────────────
+
+function GameRow({ game, onReplay }: { game: GameSummary; onReplay: () => void }) {
+  const { t } = useTranslation()
+  const result = resultForGame(game, t)
+
+  return (
+    <tr className="border-b border-border last:border-0 hover:bg-muted/30 transition-colors">
+      {/* Date */}
+      <td className="py-3 pr-4 text-sm text-muted-foreground whitespace-nowrap">
+        {formatDate(game.updatedAt)}
+      </td>
+
+      {/* Mode */}
+      <td className="py-3 pr-4">
+        <span className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground px-2 py-0.5 rounded-full border border-border bg-muted/50">
+          <ModeIcon mode={game.config.mode} />
+          {modeLabel(game.config.mode, t)}
+        </span>
+      </td>
+
+      {/* Opponent */}
+      <td className="py-3 pr-4 font-medium text-sm truncate max-w-[120px]">
+        {opponentName(game)}
+      </td>
+
+      {/* Board size */}
+      <td className="py-3 pr-4 text-sm text-muted-foreground hidden sm:table-cell">
+        {game.config.boardSize}×{game.config.boardSize}
+      </td>
+
+      {/* Move count */}
+      <td className="py-3 pr-4 text-sm text-muted-foreground hidden md:table-cell font-mono">
+        {t('history.moves', { count: game.moveCount })}
+      </td>
+
+      {/* Result */}
+      <td className="py-3 pr-4">
+        <span className={cn('text-xs font-semibold px-2 py-0.5 rounded-full', result.className)}>
+          {result.label}
+        </span>
+      </td>
+
+      {/* Action */}
+      <td className="py-3">
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onReplay}
+          className="gap-1.5 h-7 text-xs"
+          disabled={game.moveCount === 0}
+        >
+          <Play className="w-3 h-3" />
+          {t('history.watchReplay')}
+        </Button>
+      </td>
+    </tr>
+  )
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export function GameHistoryPage() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { games, isLoading, error, isGuest } = useGameHistoryController()
+
+  // Guest upsell
+  if (isGuest) {
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" onClick={() => navigate(-1)}>
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            {t('common.back')}
+          </Button>
+          <h1 className="text-3xl font-bold">{t('history.title')}</h1>
+        </div>
+        <Card>
+          <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
+            <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
+              <BarChart2 className="w-8 h-8 text-primary" />
+            </div>
+            <div className="space-y-1">
+              <h2 className="text-xl font-semibold">{t('stats.trackProgress')}</h2>
+              <p className="text-muted-foreground max-w-xs mx-auto text-sm">
+                {t('stats.trackProgressDescription')}
+              </p>
+            </div>
+            <div className="flex gap-3">
+              <Button onClick={() => navigate('/register')}>{t('stats.createAccount')}</Button>
+              <Button variant="outline" onClick={() => navigate('/login')}>{t('stats.signIn')}</Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" onClick={() => navigate(-1)}>
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          {t('common.back')}
+        </Button>
+        <h1 className="text-3xl font-bold">{t('history.title')}</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Trophy className="w-5 h-5 text-primary" />
+            {t('history.tableTitle')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex justify-center py-12">
+              <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+            </div>
+          ) : error ? (
+            <p className="text-center text-sm text-destructive py-8">{error}</p>
+          ) : games.length === 0 ? (
+            <p className="text-center text-sm text-muted-foreground py-12">
+              {t('history.noGames')}
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border text-muted-foreground text-left">
+                    <th className="pb-2 font-medium pr-4">{t('history.colDate')}</th>
+                    <th className="pb-2 font-medium pr-4">{t('history.colMode')}</th>
+                    <th className="pb-2 font-medium pr-4">{t('history.colOpponent')}</th>
+                    <th className="pb-2 font-medium pr-4 hidden sm:table-cell">{t('history.colBoard')}</th>
+                    <th className="pb-2 font-medium pr-4 hidden md:table-cell">{t('history.colMoves')}</th>
+                    <th className="pb-2 font-medium pr-4">{t('history.colResult')}</th>
+                    <th className="pb-2 font-medium" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {games.map(game => (
+                    <GameRow
+                      key={game.id}
+                      game={game}
+                      onReplay={() => navigate(`/games/y/replay/${game.id}`)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/webapp/src/pages/GameReplayPage.tsx
+++ b/webapp/src/pages/GameReplayPage.tsx
@@ -1,0 +1,243 @@
+import { useTranslation } from 'react-i18next'
+import { useGameReplayController } from '@/controllers/useGameReplayController'
+import { GameYBoard } from '@/components/game-y/GameYBoard'
+import { Button } from '@/components/ui/Button'
+import { AlertCircle, ArrowLeft, ChevronFirst, ChevronLast, ChevronLeft, ChevronRight, Bot, Users, Globe } from 'lucide-react'
+import { cn } from '@/utils'
+import type { GameMode, PlayerColor } from '@/types'
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function ModeChip({ mode }: { mode: GameMode }) {
+  const icons = { pve: Bot, 'pvp-local': Users, 'pvp-online': Globe }
+  const Icon = icons[mode] ?? Globe
+  const labels = { pve: 'vs Bot', 'pvp-local': 'Local', 'pvp-online': 'Online' }
+  return (
+    <span className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground px-2 py-0.5 rounded-full border border-border bg-muted/50">
+      <Icon className="w-3 h-3" />
+      {labels[mode]}
+    </span>
+  )
+}
+
+function ResultChip({ winner, humanColor }: { winner: PlayerColor | null; humanColor: PlayerColor | null }) {
+  if (!winner) return null
+  if (!humanColor) {
+    const name = winner === 'player1' ? 'Player 1' : 'Player 2'
+    return <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-primary/10 text-primary">{name} won</span>
+  }
+  const isWin = winner === humanColor
+  return (
+    <span className={cn(
+      'text-xs font-semibold px-2 py-0.5 rounded-full',
+      isWin ? 'bg-player1/10 text-player1' : 'bg-player2/10 text-player2'
+    )}>
+      {isWin ? 'Win' : 'Loss'}
+    </span>
+  )
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export function GameReplayPage() {
+  const { t } = useTranslation()
+  const {
+    game,
+    boardAtStep,
+    step,
+    totalMoves,
+    currentMove,
+    isLoading,
+    error,
+    canGoBack,
+    canGoForward,
+    goBack,
+    goForward,
+    goToStart,
+    goToEnd,
+    setStep,
+    goToHistory,
+  } = useGameReplayController()
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-12 h-12 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+          <p className="text-muted-foreground">{t('common.loading')}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !game || !boardAtStep) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-center p-4">
+        <AlertCircle className="w-12 h-12 text-destructive mb-4" />
+        <p className="text-lg text-destructive">{error || t('game.gameNotFound')}</p>
+        <Button variant="ghost" className="mt-4" onClick={goToHistory}>
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          {t('history.title')}
+        </Button>
+      </div>
+    )
+  }
+
+  const humanIsPlayer1 = !game.players.player1.isBot
+  const humanColor: PlayerColor | null = humanIsPlayer1 ? 'player1' : 'player2'
+
+  // The board's "game-like" object we pass to GameYBoard (read-only mode)
+  const replayGame = { ...game, board: boardAtStep, status: 'playing' as const, winner: null }
+
+  // The last move to highlight is the one at the current step (step - 1 index)
+  const highlightMove = currentMove ?? null
+
+  // Player name for current-move label
+  const currentMovePlayer = currentMove
+    ? (currentMove.player === 'player1' ? game.players.player1.name : game.players.player2.name)
+    : null
+
+  const currentMoveColor: PlayerColor | null = currentMove?.player ?? null
+
+  return (
+    <div className="h-full min-h-0 flex flex-col">
+      {/* Top bar */}
+      <div className="flex-shrink-0 border-b border-border bg-card px-4 py-2 flex flex-wrap items-center gap-3">
+        <Button variant="ghost" size="sm" onClick={goToHistory} className="gap-1.5">
+          <ArrowLeft className="w-4 h-4" />
+          {t('history.title')}
+        </Button>
+
+        <div className="flex items-center gap-2 flex-wrap">
+          <ModeChip mode={game.config.mode} />
+          <span className="text-xs text-muted-foreground">
+            {game.config.boardSize}×{game.config.boardSize}
+          </span>
+          <span className="text-xs text-muted-foreground hidden sm:inline">
+            {new Date(game.updatedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}
+          </span>
+          <ResultChip winner={game.winner} humanColor={humanColor} />
+        </div>
+
+        {/* Player legend */}
+        <div className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <span className="w-2.5 h-2.5 rounded-full bg-player1 inline-block" />
+            {game.players.player1.name}
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2.5 h-2.5 rounded-full bg-player2 inline-block" />
+            {game.players.player2.name}
+          </span>
+        </div>
+      </div>
+
+      {/* Board */}
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <GameYBoard
+          game={replayGame}
+          lastMove={highlightMove}
+          isInteractive={false}
+          onCellClick={() => {}}
+        />
+      </div>
+
+      {/* Controls bar */}
+      <div className="flex-shrink-0 border-t border-border bg-card px-4 py-3 space-y-3">
+        {/* Move info */}
+        <div className="text-center text-sm min-h-[1.5rem]">
+          {step === 0 ? (
+            <span className="text-muted-foreground italic">{t('replay.emptyBoard')}</span>
+          ) : currentMovePlayer && currentMoveColor ? (
+            <span>
+              <span
+                className={cn(
+                  'font-semibold',
+                  currentMoveColor === 'player1' ? 'text-player1' : 'text-player2'
+                )}
+              >
+                {currentMovePlayer}
+              </span>
+              {' '}
+              <span className="text-muted-foreground">
+                {t('replay.played', { row: currentMove!.row, col: currentMove!.col })}
+              </span>
+            </span>
+          ) : null}
+        </div>
+
+        {/* Scrubber */}
+        <input
+          type="range"
+          min={0}
+          max={totalMoves}
+          value={step}
+          onChange={e => setStep(Number(e.target.value))}
+          className="w-full h-1.5 rounded-full accent-primary cursor-pointer"
+          aria-label={t('replay.scrubber')}
+        />
+
+        {/* Buttons + counter */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goToStart}
+              disabled={!canGoBack}
+              className="h-8 w-8"
+              title={t('replay.goToStart')}
+            >
+              <ChevronFirst className="w-4 h-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goBack}
+              disabled={!canGoBack}
+              className="h-8 w-8"
+              title={t('replay.previousMove')}
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </Button>
+          </div>
+
+          <span className="text-sm font-mono font-medium text-muted-foreground tabular-nums select-none">
+            {step === 0
+              ? t('replay.start')
+              : step === totalMoves
+              ? t('replay.end')
+              : t('replay.stepOf', { step, total: totalMoves })}
+          </span>
+
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goForward}
+              disabled={!canGoForward}
+              className="h-8 w-8"
+              title={t('replay.nextMove')}
+            >
+              <ChevronRight className="w-4 h-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goToEnd}
+              disabled={!canGoForward}
+              className="h-8 w-8"
+              title={t('replay.goToEnd')}
+            >
+              <ChevronLast className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+
+        <p className="text-center text-xs text-muted-foreground/60 hidden sm:block">
+          {t('replay.keyboardHint')}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/pages/GameReplayPage.tsx
+++ b/webapp/src/pages/GameReplayPage.tsx
@@ -2,16 +2,27 @@ import { useTranslation } from 'react-i18next'
 import { useGameReplayController } from '@/controllers/useGameReplayController'
 import { GameYBoard } from '@/components/game-y/GameYBoard'
 import { Button } from '@/components/ui/Button'
-import { AlertCircle, ArrowLeft, ChevronFirst, ChevronLast, ChevronLeft, ChevronRight, Bot, Users, Globe } from 'lucide-react'
+import {
+  AlertCircle,
+  ArrowLeft,
+  ChevronFirst,
+  ChevronLast,
+  ChevronLeft,
+  ChevronRight,
+  Bot,
+  Users,
+  Globe
+} from 'lucide-react'
 import { cn } from '@/utils'
 import type { GameMode, PlayerColor } from '@/types'
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
-function ModeChip({ mode }: { mode: GameMode }) {
+function ModeChip({ mode }: Readonly<{ mode: GameMode }>) {
   const icons = { pve: Bot, 'pvp-local': Users, 'pvp-online': Globe }
   const Icon = icons[mode] ?? Globe
   const labels = { pve: 'vs Bot', 'pvp-local': 'Local', 'pvp-online': 'Online' }
+
   return (
     <span className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground px-2 py-0.5 rounded-full border border-border bg-muted/50">
       <Icon className="w-3 h-3" />
@@ -20,18 +31,30 @@ function ModeChip({ mode }: { mode: GameMode }) {
   )
 }
 
-function ResultChip({ winner, humanColor }: { winner: PlayerColor | null; humanColor: PlayerColor | null }) {
+function ResultChip({
+  winner,
+  humanColor
+}: Readonly<{ winner: PlayerColor | null; humanColor: PlayerColor | null }>) {
   if (!winner) return null
+
   if (!humanColor) {
     const name = winner === 'player1' ? 'Player 1' : 'Player 2'
-    return <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-primary/10 text-primary">{name} won</span>
+    return (
+      <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+        {name} won
+      </span>
+    )
   }
+
   const isWin = winner === humanColor
+
   return (
-    <span className={cn(
-      'text-xs font-semibold px-2 py-0.5 rounded-full',
-      isWin ? 'bg-player1/10 text-player1' : 'bg-player2/10 text-player2'
-    )}>
+    <span
+      className={cn(
+        'text-xs font-semibold px-2 py-0.5 rounded-full',
+        isWin ? 'bg-player1/10 text-player1' : 'bg-player2/10 text-player2'
+      )}
+    >
       {isWin ? 'Win' : 'Loss'}
     </span>
   )
@@ -41,6 +64,7 @@ function ResultChip({ winner, humanColor }: { winner: PlayerColor | null; humanC
 
 export function GameReplayPage() {
   const { t } = useTranslation()
+
   const {
     game,
     boardAtStep,
@@ -56,7 +80,7 @@ export function GameReplayPage() {
     goToStart,
     goToEnd,
     setStep,
-    goToHistory,
+    goToHistory
   } = useGameReplayController()
 
   if (isLoading) {
@@ -74,7 +98,9 @@ export function GameReplayPage() {
     return (
       <div className="flex flex-col items-center justify-center h-full text-center p-4">
         <AlertCircle className="w-12 h-12 text-destructive mb-4" />
-        <p className="text-lg text-destructive">{error || t('game.gameNotFound')}</p>
+        <p className="text-lg text-destructive">
+          {error || t('game.gameNotFound')}
+        </p>
         <Button variant="ghost" className="mt-4" onClick={goToHistory}>
           <ArrowLeft className="w-4 h-4 mr-2" />
           {t('history.title')}
@@ -86,18 +112,68 @@ export function GameReplayPage() {
   const humanIsPlayer1 = !game.players.player1.isBot
   const humanColor: PlayerColor | null = humanIsPlayer1 ? 'player1' : 'player2'
 
-  // The board's "game-like" object we pass to GameYBoard (read-only mode)
-  const replayGame = { ...game, board: boardAtStep, status: 'playing' as const, winner: null }
+  const replayGame = {
+    ...game,
+    board: boardAtStep,
+    status: 'playing' as const,
+    winner: null
+  }
 
-  // The last move to highlight is the one at the current step (step - 1 index)
   const highlightMove = currentMove ?? null
 
-  // Player name for current-move label
-  const currentMovePlayer = currentMove
-    ? (currentMove.player === 'player1' ? game.players.player1.name : game.players.player2.name)
-    : null
+  // ─── MOVE PLAYER (refactor ternario → if) ──────────────────────────────────
+  let currentMovePlayer: string | null = null
+
+  if (currentMove) {
+    if (currentMove.player === 'player1') {
+      currentMovePlayer = game.players.player1.name
+    } else {
+      currentMovePlayer = game.players.player2.name
+    }
+  }
 
   const currentMoveColor: PlayerColor | null = currentMove?.player ?? null
+
+  // ─── MOVE INFO (refactor ternario → if/else) ───────────────────────────────
+  let moveInfoContent: React.ReactNode = null
+
+  if (step === 0) {
+    moveInfoContent = (
+      <span className="text-muted-foreground italic">
+        {t('replay.emptyBoard')}
+      </span>
+    )
+  } else if (currentMovePlayer && currentMoveColor) {
+    moveInfoContent = (
+      <span>
+        <span
+          className={cn(
+            'font-semibold',
+            currentMoveColor === 'player1' ? 'text-player1' : 'text-player2'
+          )}
+        >
+          {currentMovePlayer}
+        </span>{' '}
+        <span className="text-muted-foreground">
+          {t('replay.played', {
+            row: currentMove!.row,
+            col: currentMove!.col
+          })}
+        </span>
+      </span>
+    )
+  }
+
+  // ─── STEP LABEL (refactor ternario → if/else) ──────────────────────────────
+  let stepLabel = ''
+
+  if (step === 0) {
+    stepLabel = t('replay.start')
+  } else if (step === totalMoves) {
+    stepLabel = t('replay.end')
+  } else {
+    stepLabel = t('replay.stepOf', { step, total: totalMoves })
+  }
 
   return (
     <div className="h-full min-h-0 flex flex-col">
@@ -114,12 +190,15 @@ export function GameReplayPage() {
             {game.config.boardSize}×{game.config.boardSize}
           </span>
           <span className="text-xs text-muted-foreground hidden sm:inline">
-            {new Date(game.updatedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}
+            {new Date(game.updatedAt).toLocaleDateString(undefined, {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric'
+            })}
           </span>
           <ResultChip winner={game.winner} humanColor={humanColor} />
         </div>
 
-        {/* Player legend */}
         <div className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
           <span className="flex items-center gap-1">
             <span className="w-2.5 h-2.5 rounded-full bg-player1 inline-block" />
@@ -142,31 +221,12 @@ export function GameReplayPage() {
         />
       </div>
 
-      {/* Controls bar */}
+      {/* Controls */}
       <div className="flex-shrink-0 border-t border-border bg-card px-4 py-3 space-y-3">
-        {/* Move info */}
         <div className="text-center text-sm min-h-[1.5rem]">
-          {step === 0 ? (
-            <span className="text-muted-foreground italic">{t('replay.emptyBoard')}</span>
-          ) : currentMovePlayer && currentMoveColor ? (
-            <span>
-              <span
-                className={cn(
-                  'font-semibold',
-                  currentMoveColor === 'player1' ? 'text-player1' : 'text-player2'
-                )}
-              >
-                {currentMovePlayer}
-              </span>
-              {' '}
-              <span className="text-muted-foreground">
-                {t('replay.played', { row: currentMove!.row, col: currentMove!.col })}
-              </span>
-            </span>
-          ) : null}
+          {moveInfoContent}
         </div>
 
-        {/* Scrubber */}
         <input
           type="range"
           min={0}
@@ -174,61 +234,27 @@ export function GameReplayPage() {
           value={step}
           onChange={e => setStep(Number(e.target.value))}
           className="w-full h-1.5 rounded-full accent-primary cursor-pointer"
-          aria-label={t('replay.scrubber')}
         />
 
-        {/* Buttons + counter */}
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-1">
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={goToStart}
-              disabled={!canGoBack}
-              className="h-8 w-8"
-              title={t('replay.goToStart')}
-            >
+            <Button variant="outline" size="icon" onClick={goToStart} disabled={!canGoBack} className="h-8 w-8">
               <ChevronFirst className="w-4 h-4" />
             </Button>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={goBack}
-              disabled={!canGoBack}
-              className="h-8 w-8"
-              title={t('replay.previousMove')}
-            >
+            <Button variant="outline" size="icon" onClick={goBack} disabled={!canGoBack} className="h-8 w-8">
               <ChevronLeft className="w-4 h-4" />
             </Button>
           </div>
 
           <span className="text-sm font-mono font-medium text-muted-foreground tabular-nums select-none">
-            {step === 0
-              ? t('replay.start')
-              : step === totalMoves
-              ? t('replay.end')
-              : t('replay.stepOf', { step, total: totalMoves })}
+            {stepLabel}
           </span>
 
           <div className="flex items-center gap-1">
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={goForward}
-              disabled={!canGoForward}
-              className="h-8 w-8"
-              title={t('replay.nextMove')}
-            >
+            <Button variant="outline" size="icon" onClick={goForward} disabled={!canGoForward} className="h-8 w-8">
               <ChevronRight className="w-4 h-4" />
             </Button>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={goToEnd}
-              disabled={!canGoForward}
-              className="h-8 w-8"
-              title={t('replay.goToEnd')}
-            >
+            <Button variant="outline" size="icon" onClick={goToEnd} disabled={!canGoForward} className="h-8 w-8">
               <ChevronLast className="w-4 h-4" />
             </Button>
           </div>

--- a/webapp/src/pages/GameReplayPage.tsx
+++ b/webapp/src/pages/GameReplayPage.tsx
@@ -98,9 +98,7 @@ export function GameReplayPage() {
     return (
       <div className="flex flex-col items-center justify-center h-full text-center p-4">
         <AlertCircle className="w-12 h-12 text-destructive mb-4" />
-        <p className="text-lg text-destructive">
-          {error || t('game.gameNotFound')}
-        </p>
+        <p className="text-lg text-destructive">{error || t('game.gameNotFound')}</p>
         <Button variant="ghost" className="mt-4" onClick={goToHistory}>
           <ArrowLeft className="w-4 h-4 mr-2" />
           {t('history.title')}
@@ -112,16 +110,10 @@ export function GameReplayPage() {
   const humanIsPlayer1 = !game.players.player1.isBot
   const humanColor: PlayerColor | null = humanIsPlayer1 ? 'player1' : 'player2'
 
-  const replayGame = {
-    ...game,
-    board: boardAtStep,
-    status: 'playing' as const,
-    winner: null
-  }
-
+  const replayGame = { ...game, board: boardAtStep, status: 'playing' as const, winner: null }
   const highlightMove = currentMove ?? null
 
-  // ─── MOVE PLAYER (refactor ternario → if) ──────────────────────────────────
+  // ─── MOVE PLAYER ────────────────────────────────────────────────────────────
   let currentMovePlayer: string | null = null
 
   if (currentMove) {
@@ -134,7 +126,7 @@ export function GameReplayPage() {
 
   const currentMoveColor: PlayerColor | null = currentMove?.player ?? null
 
-  // ─── MOVE INFO (refactor ternario → if/else) ───────────────────────────────
+  // ─── MOVE INFO ─────────────────────────────────────────────────────────────
   let moveInfoContent: React.ReactNode = null
 
   if (step === 0) {
@@ -155,16 +147,13 @@ export function GameReplayPage() {
           {currentMovePlayer}
         </span>{' '}
         <span className="text-muted-foreground">
-          {t('replay.played', {
-            row: currentMove!.row,
-            col: currentMove!.col
-          })}
+          {t('replay.played', { row: currentMove!.row, col: currentMove!.col })}
         </span>
       </span>
     )
   }
 
-  // ─── STEP LABEL (refactor ternario → if/else) ──────────────────────────────
+  // ─── STEP LABEL ─────────────────────────────────────────────────────────────
   let stepLabel = ''
 
   if (step === 0) {
@@ -177,6 +166,7 @@ export function GameReplayPage() {
 
   return (
     <div className="h-full min-h-0 flex flex-col">
+
       {/* Top bar */}
       <div className="flex-shrink-0 border-b border-border bg-card px-4 py-2 flex flex-wrap items-center gap-3">
         <Button variant="ghost" size="sm" onClick={goToHistory} className="gap-1.5">
@@ -185,29 +175,17 @@ export function GameReplayPage() {
         </Button>
 
         <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-medium text-player1">{game.players.player1.name}</span>
+            {' vs '}
+          <span className="font-medium text-player2">{game.players.player2.name}</span>
           <ModeChip mode={game.config.mode} />
           <span className="text-xs text-muted-foreground">
             {game.config.boardSize}×{game.config.boardSize}
           </span>
           <span className="text-xs text-muted-foreground hidden sm:inline">
-            {new Date(game.updatedAt).toLocaleDateString(undefined, {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric'
-            })}
+            {new Date(game.updatedAt).toLocaleDateString()}
           </span>
           <ResultChip winner={game.winner} humanColor={humanColor} />
-        </div>
-
-        <div className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
-          <span className="flex items-center gap-1">
-            <span className="w-2.5 h-2.5 rounded-full bg-player1 inline-block" />
-            {game.players.player1.name}
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="w-2.5 h-2.5 rounded-full bg-player2 inline-block" />
-            {game.players.player2.name}
-          </span>
         </div>
       </div>
 
@@ -223,6 +201,7 @@ export function GameReplayPage() {
 
       {/* Controls */}
       <div className="flex-shrink-0 border-t border-border bg-card px-4 py-3 space-y-3">
+
         <div className="text-center text-sm min-h-[1.5rem]">
           {moveInfoContent}
         </div>
@@ -237,11 +216,27 @@ export function GameReplayPage() {
         />
 
         <div className="flex items-center justify-between gap-2">
+
           <div className="flex items-center gap-1">
-            <Button variant="outline" size="icon" onClick={goToStart} disabled={!canGoBack} className="h-8 w-8">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goToStart}
+              disabled={!canGoBack}
+              aria-label="Go to start"
+              title="Go to start"
+            >
               <ChevronFirst className="w-4 h-4" />
             </Button>
-            <Button variant="outline" size="icon" onClick={goBack} disabled={!canGoBack} className="h-8 w-8">
+
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goBack}
+              disabled={!canGoBack}
+              aria-label="Previous move"
+              title="Previous move"
+            >
               <ChevronLeft className="w-4 h-4" />
             </Button>
           </div>
@@ -251,17 +246,33 @@ export function GameReplayPage() {
           </span>
 
           <div className="flex items-center gap-1">
-            <Button variant="outline" size="icon" onClick={goForward} disabled={!canGoForward} className="h-8 w-8">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goForward}
+              disabled={!canGoForward}
+              aria-label="Next move"
+              title="Next move"
+            >
               <ChevronRight className="w-4 h-4" />
             </Button>
-            <Button variant="outline" size="icon" onClick={goToEnd} disabled={!canGoForward} className="h-8 w-8">
+
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goToEnd}
+              disabled={!canGoForward}
+              aria-label="Go to end"
+              title="Go to end"
+            >
               <ChevronLast className="w-4 h-4" />
             </Button>
           </div>
+
         </div>
 
         <p className="text-center text-xs text-muted-foreground/60 hidden sm:block">
-          {t('replay.keyboardHint')}
+          ← → arrow keys to step through moves
         </p>
       </div>
     </div>

--- a/webapp/src/services/gameyService.test.ts
+++ b/webapp/src/services/gameyService.test.ts
@@ -19,6 +19,21 @@ const mockGame = {
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
 }
+const mockSummary = {
+  id: 'game-1',
+  config: { mode: 'pvp-local', boardSize: 5, timerEnabled: false },
+  status: 'finished',
+  phase: 'playing',
+  players: {
+    player1: { id: '1', name: 'TestUser', color: 'player1' },
+    player2: { id: '2', name: 'Opponent', color: 'player2' },
+  },
+  winner: 'player1',
+  moveCount: 8,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+ 
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -81,6 +96,102 @@ describe('GameService', () => {
       await expect(gameService.getGameState('game-1')).rejects.toThrow()
     })
   })
+
+ describe('getUserGames', () => {
+    it('calls GET /api/games with Authorization header', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [mockSummary],
+      } as any)
+ 
+      await gameService.getUserGames('my-token')
+ 
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/games'),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer my-token' }),
+        })
+      )
+    })
+ 
+    it('does NOT include a method (defaults to GET)', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      } as any)
+ 
+      await gameService.getUserGames('token')
+ 
+      const [, options] = vi.mocked(fetch).mock.calls[0]
+      expect((options as RequestInit).method).toBeUndefined()
+    })
+ 
+    it('returns an array of game summaries on success', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [mockSummary, { ...mockSummary, id: 'game-2' }],
+      } as any)
+ 
+      const result = await gameService.getUserGames('token')
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('game-1')
+      expect(result[1].id).toBe('game-2')
+    })
+ 
+    it('returns an empty array when server returns empty array', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      } as any)
+ 
+      const result = await gameService.getUserGames('token')
+      expect(result).toHaveLength(0)
+    })
+ 
+    it('summaries contain moveCount', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [mockSummary],
+      } as any)
+ 
+      const [summary] = await gameService.getUserGames('token')
+      expect(summary.moveCount).toBe(8)
+    })
+ 
+    it('throws using data.error on non-ok response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: 'Unauthorized' }),
+      } as any)
+ 
+      await expect(gameService.getUserGames('bad-token')).rejects.toThrow('Unauthorized')
+    })
+ 
+    it('throws generic message when json() fails on error response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => { throw new Error('not json') },
+      } as any)
+ 
+      await expect(gameService.getUserGames('token')).rejects.toThrow('Failed to fetch game history')
+    })
+ 
+    it('the URL targets the /api/games endpoint (not a sub-route)', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      } as any)
+ 
+      await gameService.getUserGames('token')
+ 
+      const [url] = vi.mocked(fetch).mock.calls[0]
+      // Should end with /games, not /games/something
+      expect(String(url)).toMatch(/\/games$/)
+    })
+  })
+
 
   describe('playMove', () => {
     it('calls POST /api/games/:id/move with row, col, player', async () => {

--- a/webapp/src/services/gameyService.ts
+++ b/webapp/src/services/gameyService.ts
@@ -1,6 +1,7 @@
 import type {
   GameInfo,
   GameState,
+  GameSummary,
   GameConfig,
   ChatMessage,
   PieDecision,
@@ -42,6 +43,20 @@ class GameService {
     const response = await fetch(`${this.baseUrl}/games/${gameId}`)
     if (response.status === 404) return null
     if (!response.ok) throw new Error(`Failed to get game state: ${response.status}`)
+    return response.json()
+  }
+
+  async getUserGames(token: string): Promise<GameSummary[]> {
+    const response = await fetch(`${this.baseUrl}/games`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({ error: 'Failed to fetch game history' }))
+      throw new Error(err.error || `Failed to fetch game history: ${response.status}`)
+    }
     return response.json()
   }
 

--- a/webapp/src/test/GameHistoryPage.test.tsx
+++ b/webapp/src/test/GameHistoryPage.test.tsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { GameHistoryPage } from '@/pages/GameHistoryPage'
+import { useGameHistoryController } from '@/controllers/useGameHistoryController'
+
+vi.mock('@/controllers/useGameHistoryController', () => ({
+  useGameHistoryController: vi.fn(),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeSummary(overrides = {}) {
+  return {
+    id: 'g1',
+    config: { mode: 'pvp-local', boardSize: 5, timerEnabled: false },
+    status: 'finished',
+    phase: 'playing',
+    players: {
+      player1: { id: 'u1', name: 'Alice', color: 'player1' },
+      player2: { id: 'u2', name: 'Bob', color: 'player2' },
+    },
+    winner: 'player1',
+    moveCount: 10,
+    createdAt: new Date('2026-01-15T10:00:00Z').toISOString(),
+    updatedAt: new Date('2026-01-15T10:05:00Z').toISOString(),
+    ...overrides,
+  }
+}
+
+function makeController(overrides = {}) {
+  return {
+    games: [makeSummary()],
+    isLoading: false,
+    error: null,
+    isGuest: false,
+    ...overrides,
+  }
+}
+
+function renderPage(controllerOverrides = {}) {
+  vi.mocked(useGameHistoryController).mockReturnValue(
+    makeController(controllerOverrides) as any
+  )
+  return render(
+    <MemoryRouter>
+      <GameHistoryPage />
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockNavigate.mockReset()
+})
+
+// ─── Header & chrome ──────────────────────────────────────────────────────────
+
+describe('GameHistoryPage — header', () => {
+  it('renders the page title', () => {
+    renderPage()
+    expect(screen.getByText('Game History')).toBeDefined()
+  })
+
+  it('renders the back button', () => {
+    renderPage()
+    expect(screen.getByText('Back')).toBeDefined()
+  })
+
+  it('calls navigate(-1) when back button is clicked', () => {
+    renderPage()
+    fireEvent.click(screen.getByText('Back'))
+    expect(mockNavigate).toHaveBeenCalledWith(-1)
+  })
+})
+
+// ─── Loading state ────────────────────────────────────────────────────────────
+
+describe('GameHistoryPage — loading', () => {
+  it('shows a spinner when isLoading is true', () => {
+    renderPage({ isLoading: true, games: [] })
+    expect(
+      document.querySelector('.animate-spin')
+    ).not.toBeNull()
+  })
+
+  it('does not render the table while loading', () => {
+    renderPage({ isLoading: true, games: [] })
+    expect(screen.queryByText('Date')).toBeNull()
+  })
+})
+
+// ─── Error state ──────────────────────────────────────────────────────────────
+
+describe('GameHistoryPage — error', () => {
+  it('displays the error message', () => {
+    renderPage({ error: 'Service unavailable', games: [] })
+    expect(screen.getByText('Service unavailable')).toBeDefined()
+  })
+
+  it('does not render the table on error', () => {
+    renderPage({ error: 'Service unavailable', games: [] })
+    expect(screen.queryByText('Date')).toBeNull()
+  })
+})
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+describe('GameHistoryPage — empty state', () => {
+  it('shows empty state message when games list is empty', () => {
+    renderPage({ games: [] })
+    expect(screen.getByText('No games played yet.')).toBeDefined()
+  })
+
+  it('does not show the table when games list is empty', () => {
+    renderPage({ games: [] })
+    expect(screen.queryByText('Date')).toBeNull()
+  })
+})
+
+// ─── Table rendering ──────────────────────────────────────────────────────────
+
+describe('GameHistoryPage — table', () => {
+  it('renders table column headers', () => {
+    renderPage()
+    expect(screen.getByText('Date')).toBeDefined()
+    expect(screen.getByText('Mode')).toBeDefined()
+    expect(screen.getByText('Opponent')).toBeDefined()
+    expect(screen.getByText('Result')).toBeDefined()
+  })
+
+  it('renders a row for each game', () => {
+    renderPage({
+      games: [
+        makeSummary({ id: 'g1' }),
+        makeSummary({ id: 'g2', winner: 'player2' }),
+      ],
+    })
+    // Two "Replay" buttons = two rows
+    expect(screen.getAllByText('Replay')).toHaveLength(2)
+  })
+
+  it('displays the opponent name', () => {
+    renderPage()
+    expect(screen.getByText('Bob')).toBeDefined()
+  })
+
+  it('shows "Win" badge when the authenticated user won', () => {
+    renderPage()
+    expect(screen.getByText('Win')).toBeDefined()
+  })
+
+  it('shows "Loss" badge when the authenticated user lost', () => {
+    renderPage({
+      games: [makeSummary({ winner: 'player2' })],
+    })
+    expect(screen.getByText('Loss')).toBeDefined()
+  })
+
+  it('shows "Draw" badge when there is no winner', () => {
+    renderPage({
+      games: [makeSummary({ winner: null })],
+    })
+    expect(screen.getByText('Draw')).toBeDefined()
+  })
+
+  it('shows mode chip for pvp-local', () => {
+    renderPage()
+    expect(screen.getByText('Local')).toBeDefined()
+  })
+
+  it('shows mode chip for pve', () => {
+    renderPage({
+      games: [makeSummary({ config: { mode: 'pve', boardSize: 9, timerEnabled: false } })],
+    })
+    expect(screen.getByText('vs Bot')).toBeDefined()
+  })
+
+  it('shows mode chip for pvp-online', () => {
+    renderPage({
+      games: [makeSummary({ config: { mode: 'pvp-online', boardSize: 9, timerEnabled: false } })],
+    })
+    expect(screen.getByText('Online')).toBeDefined()
+  })
+})
+
+// ─── Replay button ────────────────────────────────────────────────────────────
+
+describe('GameHistoryPage — replay action', () => {
+  it('clicking Replay navigates to the replay page', () => {
+    renderPage()
+    fireEvent.click(screen.getByText('Replay'))
+    expect(mockNavigate).toHaveBeenCalledWith('/games/y/replay/g1')
+  })
+
+  it('Replay button is disabled when moveCount is 0', () => {
+    renderPage({ games: [makeSummary({ moveCount: 0 })] })
+    const btn = screen.getByText('Replay').closest('button') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('Replay button is enabled when moveCount > 0', () => {
+    renderPage()
+    const btn = screen.getByText('Replay').closest('button') as HTMLButtonElement
+    expect(btn.disabled).toBe(false)
+  })
+})
+
+// ─── Guest upsell ─────────────────────────────────────────────────────────────
+
+describe('GameHistoryPage — guest view', () => {
+  it('renders the upsell heading for guests', () => {
+    renderPage({ isGuest: true, games: [] })
+    expect(screen.getByText('Track Your Progress')).toBeDefined()
+  })
+
+  it('does not render the table for guests', () => {
+    renderPage({ isGuest: true, games: [] })
+    expect(screen.queryByText('Date')).toBeNull()
+    expect(screen.queryByText('Replay')).toBeNull()
+  })
+
+  it('shows Create Account button for guests', () => {
+    renderPage({ isGuest: true, games: [] })
+    expect(screen.getByText('Create Account')).toBeDefined()
+  })
+
+  it('shows Sign In button for guests', () => {
+    renderPage({ isGuest: true, games: [] })
+    expect(screen.getByText('Sign In')).toBeDefined()
+  })
+
+  it('navigates to /register when Create Account is clicked', () => {
+    renderPage({ isGuest: true, games: [] })
+    fireEvent.click(screen.getByText('Create Account'))
+    expect(mockNavigate).toHaveBeenCalledWith('/register')
+  })
+
+  it('navigates to /login when Sign In is clicked', () => {
+    renderPage({ isGuest: true, games: [] })
+    fireEvent.click(screen.getByText('Sign In'))
+    expect(mockNavigate).toHaveBeenCalledWith('/login')
+  })
+
+  it('still shows the page title and back button for guests', () => {
+    renderPage({ isGuest: true, games: [] })
+    expect(screen.getByText('Game History')).toBeDefined()
+    expect(screen.getByText('Back')).toBeDefined()
+  })
+})

--- a/webapp/src/test/GameReplyPage.test.tsx
+++ b/webapp/src/test/GameReplyPage.test.tsx
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { GameReplayPage } from '@/pages/GameReplayPage'
+import { useGameReplayController } from '@/controllers/useGameReplayController'
+import type { BoardCell, GameState, Move } from '@/types'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/controllers/useGameReplayController', () => ({
+  useGameReplayController: vi.fn(),
+}))
+
+vi.mock('@/components/game-y/GameYBoard', () => ({
+  GameYBoard: (props: any) => (
+    <div data-testid="replay-board" data-is-interactive={String(props.isInteractive)}>
+      Board
+    </div>
+  ),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ gameId: 'test-game' }),
+}))
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeBoardAtStep(size = 5): BoardCell[][] {
+  return Array.from({ length: size }, (_, r) =>
+    Array.from({ length: r + 1 }, (_, c) => ({ row: r, col: c, owner: null }))
+  )
+}
+
+function makeMove(row: number, col: number, player: 'player1' | 'player2'): Move {
+  return { row, col, player, timestamp: Date.now() }
+}
+
+function makeGame(overrides: Partial<GameState> = {}): GameState {
+  return {
+    id: 'test-game',
+    config: { mode: 'pve', boardSize: 5 as any, timerEnabled: false },
+    status: 'finished',
+    phase: 'playing',
+    board: makeBoardAtStep(),
+    players: {
+      player1: { id: 'u1', name: 'Alice', color: 'player1' },
+      player2: { id: 'bot', name: 'Bot (medium)', color: 'player2', isBot: true },
+    },
+    currentTurn: 'player1',
+    moves: [
+      makeMove(0, 0, 'player1'),
+      makeMove(1, 0, 'player2'),
+      makeMove(2, 0, 'player1'),
+    ],
+    winner: 'player1',
+    timer: null,
+    createdAt: new Date('2026-01-15T10:00:00Z').toISOString(),
+    updatedAt: new Date('2026-01-15T10:05:00Z').toISOString(),
+    ...overrides,
+  }
+}
+
+function makeController(overrides = {}) {
+  const game = makeGame()
+  return {
+    game,
+    boardAtStep: makeBoardAtStep(),
+    step: 3,
+    totalMoves: 3,
+    currentMove: makeMove(2, 0, 'player1'),
+    isLoading: false,
+    error: null,
+    canGoBack: true,
+    canGoForward: false,
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+    goToStart: vi.fn(),
+    goToEnd: vi.fn(),
+    setStep: vi.fn(),
+    goToHistory: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderPage(controllerOverrides = {}) {
+  vi.mocked(useGameReplayController).mockReturnValue(
+    makeController(controllerOverrides) as any
+  )
+  return render(<GameReplayPage />)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockNavigate.mockReset()
+})
+
+// ─── Loading & error ──────────────────────────────────────────────────────────
+
+describe('GameReplayPage — loading', () => {
+  it('shows loading spinner when isLoading is true', () => {
+    renderPage({ isLoading: true, game: null, boardAtStep: null })
+    expect(document.querySelector('.animate-spin')).not.toBeNull()
+  })
+
+  it('does not render the board while loading', () => {
+    renderPage({ isLoading: true, game: null, boardAtStep: null })
+    expect(screen.queryByTestId('replay-board')).toBeNull()
+  })
+})
+
+describe('GameReplayPage — error', () => {
+  it('shows error message', () => {
+    renderPage({ error: 'Game not found', game: null, boardAtStep: null })
+    expect(screen.getByText('Game not found')).toBeDefined()
+  })
+
+  it('shows a back-to-history button on error', () => {
+    renderPage({ error: 'Game not found', game: null, boardAtStep: null })
+    expect(screen.getByText('Game History')).toBeDefined()
+  })
+
+  it('calls goToHistory on error back button click', () => {
+    const goToHistory = vi.fn()
+    renderPage({ error: 'Game not found', game: null, boardAtStep: null, goToHistory })
+    fireEvent.click(screen.getByText('Game History'))
+    expect(goToHistory).toHaveBeenCalled()
+  })
+})
+
+// ─── Board rendering ──────────────────────────────────────────────────────────
+
+describe('GameReplayPage — board', () => {
+  it('renders the game board', () => {
+    renderPage()
+    expect(screen.getByTestId('replay-board')).toBeDefined()
+  })
+
+  it('board is always non-interactive (read-only replay)', () => {
+    renderPage()
+    const board = screen.getByTestId('replay-board')
+    expect(board.dataset.isInteractive).toBe('false')
+  })
+})
+
+// ─── Top bar information ──────────────────────────────────────────────────────
+
+describe('GameReplayPage — top bar', () => {
+  it('shows the Game History back link in the top bar', () => {
+    renderPage()
+    expect(screen.getByText('Game History')).toBeDefined()
+  })
+
+  it('calls goToHistory when back link is clicked', () => {
+    const goToHistory = vi.fn()
+    renderPage({ goToHistory })
+    fireEvent.click(screen.getByText('Game History'))
+    expect(goToHistory).toHaveBeenCalledOnce()
+  })
+
+  it('shows board size', () => {
+    renderPage()
+    expect(screen.getByText('5×5')).toBeDefined()
+  })
+
+  it('shows the game date', () => {
+    renderPage()
+    // Date formatting is locale-dependent, but year should always appear
+    expect(screen.getByText(/2026/)).toBeDefined()
+  })
+
+  it('displays player1 name in legend', () => {
+    renderPage()
+    expect(screen.getAllByText('Alice')[0]).toBeDefined()
+  })
+
+  it('displays player2 name in legend', () => {
+    renderPage()
+    expect(screen.getByText('Bot (medium)')).toBeDefined()
+  })
+
+  it('shows "Win" result chip when human won', () => {
+    renderPage()
+    expect(screen.getByText('Win')).toBeDefined()
+  })
+
+  it('shows "Loss" result chip when human lost', () => {
+    renderPage({ game: makeGame({ winner: 'player2' }) })
+    expect(screen.getByText('Loss')).toBeDefined()
+  })
+
+  it('shows "vs Bot" mode chip for pve games', () => {
+    renderPage()
+    expect(screen.getByText('vs Bot')).toBeDefined()
+  })
+
+  it('shows "Local" mode chip for pvp-local games', () => {
+    renderPage({
+      game: makeGame({
+        config: { mode: 'pvp-local', boardSize: 5 as any, timerEnabled: false },
+        winner: 'player1',
+        players: {
+          player1: { id: 'u1', name: 'Alice', color: 'player1', isLocal: true },
+          player2: { id: 'u2', name: 'Bob', color: 'player2', isLocal: true },
+        },
+      }),
+    })
+    expect(screen.getByText('Local')).toBeDefined()
+  })
+})
+
+// ─── Controls ─────────────────────────────────────────────────────────────────
+
+describe('GameReplayPage — controls', () => {
+  it('renders all four navigation buttons', () => {
+    renderPage({ canGoBack: true, canGoForward: true })
+    const buttons = screen.getAllByRole('button')
+    // Should have: go-to-start, previous, next, go-to-end (+ the topbar back link is a button too)
+    expect(buttons.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('go-to-start button calls goToStart', () => {
+    const goToStart = vi.fn()
+    renderPage({ goToStart, canGoBack: true })
+    const btn = screen.getByTitle('Go to start')
+    fireEvent.click(btn)
+    expect(goToStart).toHaveBeenCalledOnce()
+  })
+
+  it('previous button calls goBack', () => {
+    const goBack = vi.fn()
+    renderPage({ goBack, canGoBack: true })
+    fireEvent.click(screen.getByTitle('Previous move'))
+    expect(goBack).toHaveBeenCalledOnce()
+  })
+
+  it('next button calls goForward', () => {
+    const goForward = vi.fn()
+    renderPage({ goForward, canGoForward: true })
+    fireEvent.click(screen.getByTitle('Next move'))
+    expect(goForward).toHaveBeenCalledOnce()
+  })
+
+  it('go-to-end button calls goToEnd', () => {
+    const goToEnd = vi.fn()
+    renderPage({ goToEnd, canGoForward: true })
+    fireEvent.click(screen.getByTitle('Go to end'))
+    expect(goToEnd).toHaveBeenCalledOnce()
+  })
+
+  it('previous and go-to-start buttons are disabled when canGoBack is false', () => {
+    renderPage({ canGoBack: false })
+    const startBtn = screen.getByTitle('Go to start').closest('button') as HTMLButtonElement
+    const prevBtn = screen.getByTitle('Previous move').closest('button') as HTMLButtonElement
+    expect(startBtn.disabled).toBe(true)
+    expect(prevBtn.disabled).toBe(true)
+  })
+
+  it('next and go-to-end buttons are disabled when canGoForward is false', () => {
+    renderPage({ canGoForward: false })
+    const nextBtn = screen.getByTitle('Next move').closest('button') as HTMLButtonElement
+    const endBtn = screen.getByTitle('Go to end').closest('button') as HTMLButtonElement
+    expect(nextBtn.disabled).toBe(true)
+    expect(endBtn.disabled).toBe(true)
+  })
+})
+
+// ─── Step counter & scrubber ──────────────────────────────────────────────────
+
+describe('GameReplayPage — step display', () => {
+  it('shows "End" when at the last step', () => {
+    renderPage({ step: 3, totalMoves: 3, canGoForward: false })
+    expect(screen.getByText('End')).toBeDefined()
+  })
+
+  it('shows "Start" when at step 0', () => {
+    renderPage({ step: 0, totalMoves: 3, currentMove: null, canGoBack: false })
+    expect(screen.getByText('Start')).toBeDefined()
+  })
+
+  it('shows "N / total" when at an intermediate step', () => {
+    renderPage({ step: 2, totalMoves: 3, canGoBack: true, canGoForward: true })
+    expect(screen.getByText('2 / 3')).toBeDefined()
+  })
+
+  it('renders the scrubber range input', () => {
+    renderPage()
+    const scrubber = screen.getByRole('slider')
+    expect(scrubber).toBeDefined()
+  })
+
+  it('scrubber max equals totalMoves', () => {
+    renderPage({ totalMoves: 3 })
+    const scrubber = screen.getByRole('slider') as HTMLInputElement
+    expect(scrubber.max).toBe('3')
+  })
+
+  it('scrubber value equals current step', () => {
+    renderPage({ step: 2, totalMoves: 3 })
+    const scrubber = screen.getByRole('slider') as HTMLInputElement
+    expect(scrubber.value).toBe('2')
+  })
+
+  it('scrubber onChange calls setStep', () => {
+    const setStep = vi.fn()
+    renderPage({ setStep })
+    const scrubber = screen.getByRole('slider')
+    fireEvent.change(scrubber, { target: { value: '1' } })
+    expect(setStep).toHaveBeenCalledWith(1)
+  })
+})
+
+// ─── Move info ────────────────────────────────────────────────────────────────
+
+describe('GameReplayPage — move info', () => {
+  it('shows "Start position" at step 0', () => {
+    renderPage({ step: 0, currentMove: null })
+    expect(screen.getByText('Start position')).toBeDefined()
+  })
+
+  it('shows the player name who made the current move', () => {
+    renderPage({ step: 2, currentMove: makeMove(2, 0, 'player1') })
+    expect(screen.getAllByText('Alice')[0]).toBeDefined()
+  })
+
+  it('shows coordinates of the current move', () => {
+    renderPage({ step: 2, currentMove: makeMove(2, 0, 'player1') })
+    // The "played at (row, col)" string should appear
+    expect(screen.getByText(/played at \(2, 0\)/)).toBeDefined()
+  })
+})
+
+// ─── Keyboard hint ────────────────────────────────────────────────────────────
+
+describe('GameReplayPage — keyboard hint', () => {
+  it('renders the keyboard hint text', () => {
+    renderPage()
+    expect(screen.getByText(/← →/)).toBeDefined()
+  })
+})

--- a/webapp/src/test/UseGameHistoryController.test.ts
+++ b/webapp/src/test/UseGameHistoryController.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useGameHistoryController } from '@/controllers/useGameHistoryController'
+import { useAuth } from '@/contexts/AuthContext'
+import { gameService } from '@/services/gameyService'
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('@/services/gameyService', () => ({
+  gameService: { getUserGames: vi.fn() },
+}))
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockSummary = {
+  id: 'g1',
+  config: { mode: 'pvp-local', boardSize: 5, timerEnabled: false },
+  status: 'finished',
+  phase: 'playing',
+  players: {
+    player1: { id: 'u1', name: 'Alice', color: 'player1' },
+    player2: { id: 'u2', name: 'Bob', color: 'player2' },
+  },
+  winner: 'player1',
+  moveCount: 12,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+function makeAuthMock(overrides: Record<string, unknown> = {}) {
+  return {
+    token: 'mock-token',
+    user: { id: 'u1', username: 'Alice', email: 'a@b.com', createdAt: '', updatedAt: '' },
+    isAuthenticated: true,
+    isLoading: false,
+    isGuest: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    loginAsGuest: vi.fn(),
+    logout: vi.fn(),
+    updateProfile: vi.fn(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(useAuth).mockReturnValue(makeAuthMock() as any)
+  vi.mocked(gameService.getUserGames).mockResolvedValue([mockSummary] as any)
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useGameHistoryController — authenticated user', () => {
+  it('starts with isLoading true while fetching', () => {
+    const { result } = renderHook(() => useGameHistoryController())
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('sets isLoading false after data loads', async () => {
+    const { result } = renderHook(() => useGameHistoryController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+  })
+
+  it('calls getUserGames with the auth token', async () => {
+    renderHook(() => useGameHistoryController())
+    await waitFor(() => expect(gameService.getUserGames).toHaveBeenCalledWith('mock-token'))
+  })
+
+  it('populates games from the service response', async () => {
+    const { result } = renderHook(() => useGameHistoryController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.games).toHaveLength(1)
+    expect(result.current.games[0].id).toBe('g1')
+  })
+
+  it('error is null on successful load', async () => {
+    const { result } = renderHook(() => useGameHistoryController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBeNull()
+  })
+
+  it('isGuest is false for authenticated user', async () => {
+    const { result } = renderHook(() => useGameHistoryController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isGuest).toBe(false)
+  })
+
+  it('handles empty game list', async () => {
+    vi.mocked(gameService.getUserGames).mockResolvedValueOnce([])
+    const { result } = renderHook(() => useGameHistoryController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.games).toHaveLength(0)
+  })
+
+  it('sets error message when service throws an Error', async () => {
+    vi.mocked(gameService.getUserGames).mockRejectedValueOnce(new Error('Network error'))
+    const { result } = renderHook(() => useGameHistoryController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBe('Network error')
+    expect(result.current.games).toHaveLength(0)
+  })
+
+  it('sets generic error message for non-Error rejections', async () => {
+    vi.mocked(gameService.getUserGames).mockRejectedValueOnce('timeout')
+    const { result } = renderHook(() => useGameHistoryController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBe('Failed to load game history')
+  })
+})
+
+describe('useGameHistoryController — guest user', () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue(
+      makeAuthMock({ token: 'guest', isGuest: true }) as any
+    )
+  })
+
+  it('does not call getUserGames for guests', () => {
+    renderHook(() => useGameHistoryController())
+    expect(gameService.getUserGames).not.toHaveBeenCalled()
+  })
+
+  it('isLoading is immediately false for guests (no async work)', () => {
+    const { result } = renderHook(() => useGameHistoryController())
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('games is empty for guests', () => {
+    const { result } = renderHook(() => useGameHistoryController())
+    expect(result.current.games).toHaveLength(0)
+  })
+
+  it('isGuest is true', () => {
+    const { result } = renderHook(() => useGameHistoryController())
+    expect(result.current.isGuest).toBe(true)
+  })
+})
+
+describe('useGameHistoryController — no token', () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue(
+      makeAuthMock({ token: null, isAuthenticated: false }) as any
+    )
+  })
+
+  it('does not call getUserGames when token is null', () => {
+    renderHook(() => useGameHistoryController())
+    expect(gameService.getUserGames).not.toHaveBeenCalled()
+  })
+
+  it('isLoading becomes false without fetching', async () => {
+    const { result } = renderHook(() => useGameHistoryController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+  })
+})

--- a/webapp/src/test/UseGameReplayController.test.ts
+++ b/webapp/src/test/UseGameReplayController.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useGameReplayController } from '@/controllers/useGameReplayController'
+import { gameService } from '@/services/gameyService'
+import type { GameState } from '@/types'
+
+// ─── Router mocks ─────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ gameId: 'game-replay-123' }),
+  useNavigate: () => mockNavigate,
+}))
+
+vi.mock('@/services/gameyService', () => ({
+  gameService: { getGameState: vi.fn() },
+}))
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeMove(row: number, col: number, player: 'player1' | 'player2') {
+  return { row, col, player, timestamp: Date.now() }
+}
+
+function makeGame(overrides: Partial<GameState> = {}): GameState {
+  return {
+    id: 'game-replay-123',
+    config: { mode: 'pvp-local', boardSize: 5 as any, timerEnabled: false },
+    status: 'finished',
+    phase: 'playing',
+    board: [],
+    players: {
+      player1: { id: 'p1', name: 'Alice', color: 'player1' },
+      player2: { id: 'p2', name: 'Bob', color: 'player2' },
+    },
+    currentTurn: 'player1',
+    moves: [
+      makeMove(0, 0, 'player1'),
+      makeMove(1, 0, 'player2'),
+      makeMove(2, 0, 'player1'),
+    ],
+    winner: 'player1',
+    timer: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockNavigate.mockReset()
+  vi.mocked(gameService.getGameState).mockResolvedValue(makeGame())
+})
+
+// ─── Loading & error ──────────────────────────────────────────────────────────
+
+describe('useGameReplayController — loading & error', () => {
+  it('starts with isLoading true', () => {
+    const { result } = renderHook(() => useGameReplayController())
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('sets isLoading false after data loads', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+  })
+
+  it('calls getGameState with the gameId from params', async () => {
+    renderHook(() => useGameReplayController())
+    await waitFor(() => expect(gameService.getGameState).toHaveBeenCalledWith('game-replay-123'))
+  })
+
+  it('sets error when game is not found', async () => {
+    vi.mocked(gameService.getGameState).mockResolvedValueOnce(null)
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBe('Game not found')
+    expect(result.current.game).toBeNull()
+  })
+
+  it('sets error message when service throws', async () => {
+    vi.mocked(gameService.getGameState).mockRejectedValueOnce(new Error('Network error'))
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBe('Network error')
+  })
+
+  it('sets generic error for non-Error rejections', async () => {
+    vi.mocked(gameService.getGameState).mockRejectedValueOnce('timeout')
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBe('Failed to load game')
+  })
+})
+
+// ─── Initial step ─────────────────────────────────────────────────────────────
+
+describe('useGameReplayController — initial step', () => {
+  it('initial step equals totalMoves (final position)', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.step).toBe(3)
+  })
+
+  it('totalMoves matches the game moves array length', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.totalMoves).toBe(3)
+  })
+
+  it('boardAtStep is not null after load', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.boardAtStep).not.toBeNull()
+  })
+
+  it('currentMove is the last move at the final step', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.currentMove).toMatchObject({ row: 2, col: 0, player: 'player1' })
+  })
+
+  it('starts at step 0 for a game with no moves', async () => {
+    vi.mocked(gameService.getGameState).mockResolvedValueOnce(makeGame({ moves: [] }))
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.step).toBe(0)
+    expect(result.current.currentMove).toBeNull()
+  })
+})
+
+// ─── Navigation flags ─────────────────────────────────────────────────────────
+
+describe('useGameReplayController — navigation flags', () => {
+  it('canGoBack is false at step 0', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToStart())
+    expect(result.current.canGoBack).toBe(false)
+  })
+
+  it('canGoForward is false at the final step', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    // Already at final step (3)
+    expect(result.current.canGoForward).toBe(false)
+  })
+
+  it('canGoBack is true when step > 0', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToStart())
+    act(() => result.current.goForward())
+    expect(result.current.canGoBack).toBe(true)
+  })
+
+  it('canGoForward is true when step < totalMoves', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToStart())
+    expect(result.current.canGoForward).toBe(true)
+  })
+})
+
+// ─── Step navigation ──────────────────────────────────────────────────────────
+
+describe('useGameReplayController — step navigation', () => {
+  it('goBack decrements step by 1', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goBack())
+    expect(result.current.step).toBe(2)
+  })
+
+  it('goBack does not go below 0', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToStart())
+    act(() => result.current.goBack())
+    expect(result.current.step).toBe(0)
+  })
+
+  it('goForward increments step by 1', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToStart())
+    act(() => result.current.goForward())
+    expect(result.current.step).toBe(1)
+  })
+
+  it('goForward does not exceed totalMoves', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    // Already at end (step 3)
+    act(() => result.current.goForward())
+    expect(result.current.step).toBe(3)
+  })
+
+  it('goToStart sets step to 0', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToStart())
+    expect(result.current.step).toBe(0)
+  })
+
+  it('goToEnd sets step to totalMoves', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToStart())
+    act(() => result.current.goToEnd())
+    expect(result.current.step).toBe(3)
+  })
+
+  it('setStep accepts an arbitrary valid value', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.setStep(2))
+    expect(result.current.step).toBe(2)
+  })
+
+  it('currentMove is null at step 0', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToStart())
+    expect(result.current.currentMove).toBeNull()
+  })
+
+  it('currentMove is the move played to reach the current step', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.setStep(1))
+    expect(result.current.currentMove).toMatchObject({ row: 0, col: 0, player: 'player1' })
+  })
+
+})
+
+// ─── Keyboard navigation ──────────────────────────────────────────────────────
+
+describe('useGameReplayController — keyboard navigation', () => {
+  it('ArrowLeft decrements step', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' })))
+    expect(result.current.step).toBe(2)
+  })
+
+  it('ArrowRight increments step', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToStart())
+    act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' })))
+    expect(result.current.step).toBe(1)
+  })
+
+  it('Home key goes to step 0', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' })))
+    expect(result.current.step).toBe(0)
+  })
+
+  it('End key goes to totalMoves', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToStart())
+    act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' })))
+    expect(result.current.step).toBe(3)
+  })
+
+  it('irrelevant keys are ignored', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    const stepBefore = result.current.step
+    act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' })))
+    expect(result.current.step).toBe(stepBefore)
+  })
+
+  it('removes keyboard listener on unmount', async () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+    const { unmount } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(gameService.getGameState).toHaveBeenCalled())
+    unmount()
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
+  })
+})
+
+// ─── goToHistory ──────────────────────────────────────────────────────────────
+
+describe('useGameReplayController — goToHistory', () => {
+  it('navigates to /history', async () => {
+    const { result } = renderHook(() => useGameReplayController())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.goToHistory())
+    expect(mockNavigate).toHaveBeenCalledWith('/history')
+  })
+})

--- a/webapp/src/test/replayUtils.test.ts
+++ b/webapp/src/test/replayUtils.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from 'vitest'
+import { createEmptyBoard, applyMoveToBoard, getBoardAtStep } from '@/utils/replayUtils'
+import type { GameState, Move, BoardCell } from '@/types'
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeMove(row: number, col: number, player: 'player1' | 'player2', ts = 0): Move {
+  return { row, col, player, timestamp: ts }
+}
+
+/**
+ * Build a minimal GameState for testing.
+ * `board` defaults to the final board state after all moves are applied,
+ * which is how the real API responds.
+ */
+function makeGame(
+  size: number,
+  moves: Move[],
+  overrides: Partial<GameState> = {}
+): GameState {
+  // Build a board that reflects all moves (simulates what the server returns)
+  let board: BoardCell[][] = createEmptyBoard(size)
+  for (const m of moves) {
+    board = board.map(row =>
+      row.map(cell =>
+        cell.row === m.row && cell.col === m.col ? { ...cell, owner: m.player } : cell
+      )
+    )
+  }
+
+  return {
+    id: 'test-game',
+    config: {
+      mode: 'pvp-local',
+      boardSize: size as any,
+      timerEnabled: false,
+    },
+    status: 'finished',
+    phase: 'playing',
+    board,
+    players: {
+      player1: { id: 'p1', name: 'P1', color: 'player1' },
+      player2: { id: 'p2', name: 'P2', color: 'player2' },
+    },
+    currentTurn: 'player1',
+    moves,
+    winner: null,
+    timer: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+// ─── createEmptyBoard ────────────────────────────────────────────────────────
+
+describe('createEmptyBoard', () => {
+  it('creates a board with the correct number of rows', () => {
+    const board = createEmptyBoard(5)
+    expect(board).toHaveLength(5)
+  })
+
+  it('row N has N+1 cells (triangular board)', () => {
+    const board = createEmptyBoard(5)
+    board.forEach((row, i) => {
+      expect(row).toHaveLength(i + 1)
+    })
+  })
+
+  it('all cells start with owner null', () => {
+    const board = createEmptyBoard(5)
+    board.forEach(row =>
+      row.forEach(cell => expect(cell.owner).toBeNull())
+    )
+  })
+
+  it('cell row/col coordinates are set correctly', () => {
+    const board = createEmptyBoard(4)
+    expect(board[0][0]).toEqual({ row: 0, col: 0, owner: null })
+    expect(board[3][2]).toEqual({ row: 3, col: 2, owner: null })
+  })
+
+  it('works for the minimum board size of 4', () => {
+    const board = createEmptyBoard(4)
+    expect(board).toHaveLength(4)
+    expect(board[3]).toHaveLength(4)
+  })
+
+  it('works for the maximum board size of 16', () => {
+    const board = createEmptyBoard(16)
+    expect(board).toHaveLength(16)
+    expect(board[15]).toHaveLength(16)
+  })
+})
+
+// ─── applyMoveToBoard ────────────────────────────────────────────────────────
+
+describe('applyMoveToBoard', () => {
+  it('sets the correct cell owner', () => {
+    const board = createEmptyBoard(5)
+    const updated = applyMoveToBoard(board, makeMove(2, 1, 'player1'))
+    expect(updated[2][1].owner).toBe('player1')
+  })
+
+  it('does not mutate the original board (immutability)', () => {
+    const board = createEmptyBoard(5)
+    applyMoveToBoard(board, makeMove(2, 1, 'player1'))
+    expect(board[2][1].owner).toBeNull()
+  })
+
+  it('leaves all other cells unchanged', () => {
+    const board = createEmptyBoard(4)
+    const updated = applyMoveToBoard(board, makeMove(1, 0, 'player2'))
+    // Only (1,0) should be set
+    updated.forEach((row, r) =>
+      row.forEach((cell, c) => {
+        if (r === 1 && c === 0) {
+          expect(cell.owner).toBe('player2')
+        } else {
+          expect(cell.owner).toBeNull()
+        }
+      })
+    )
+  })
+
+  it('allows overwriting an existing cell owner (for pie rule simulation)', () => {
+    const board = createEmptyBoard(5)
+    const after1 = applyMoveToBoard(board, makeMove(0, 0, 'player1'))
+    const after2 = applyMoveToBoard(after1, makeMove(0, 0, 'player2'))
+    expect(after2[0][0].owner).toBe('player2')
+  })
+})
+
+// ─── getBoardAtStep ──────────────────────────────────────────────────────────
+
+describe('getBoardAtStep', () => {
+  it('step 0 returns an empty board', () => {
+    const moves = [makeMove(0, 0, 'player1'), makeMove(1, 0, 'player2')]
+    const game = makeGame(5, moves)
+    const board = getBoardAtStep(game, 0)
+    board.forEach(row => row.forEach(cell => expect(cell.owner).toBeNull()))
+  })
+
+  it('step 1 applies only the first move', () => {
+    const moves = [makeMove(0, 0, 'player1'), makeMove(1, 0, 'player2')]
+    const game = makeGame(5, moves)
+    const board = getBoardAtStep(game, 1)
+    expect(board[0][0].owner).toBe('player1')
+    expect(board[1][0].owner).toBeNull()
+  })
+
+  it('step 2 applies both moves', () => {
+    const moves = [makeMove(0, 0, 'player1'), makeMove(1, 0, 'player2')]
+    const game = makeGame(5, moves)
+    const board = getBoardAtStep(game, 2)
+    expect(board[0][0].owner).toBe('player1')
+    expect(board[1][0].owner).toBe('player2')
+  })
+
+  it('step === totalMoves shows all moves (final position)', () => {
+    const moves = [
+      makeMove(0, 0, 'player1'),
+      makeMove(1, 0, 'player2'),
+      makeMove(2, 0, 'player1'),
+    ]
+    const game = makeGame(5, moves)
+    const board = getBoardAtStep(game, 3)
+    expect(board[0][0].owner).toBe('player1')
+    expect(board[1][0].owner).toBe('player2')
+    expect(board[2][0].owner).toBe('player1')
+  })
+
+  it('step > totalMoves is clamped to totalMoves', () => {
+    const moves = [makeMove(0, 0, 'player1')]
+    const game = makeGame(5, moves)
+    const board = getBoardAtStep(game, 999)
+    expect(board[0][0].owner).toBe('player1')
+  })
+
+  it('step < 0 is clamped to 0', () => {
+    const moves = [makeMove(0, 0, 'player1')]
+    const game = makeGame(5, moves)
+    const board = getBoardAtStep(game, -5)
+    board.forEach(row => row.forEach(cell => expect(cell.owner).toBeNull()))
+  })
+
+  it('returns the correct board size', () => {
+    const game = makeGame(6, [makeMove(0, 0, 'player1')])
+    const board = getBoardAtStep(game, 1)
+    expect(board).toHaveLength(6)
+    expect(board[5]).toHaveLength(6)
+  })
+
+  it('does not mutate the game object', () => {
+    const moves = [makeMove(0, 0, 'player1')]
+    const game = makeGame(5, moves)
+    getBoardAtStep(game, 1)
+    expect(game.board[0][0].owner).toBe('player1') // original game board untouched
+  })
+
+  it('pie rule swap: first stone owner changes to player2 from step 2', () => {
+    // After a swap the server returns board[0][0].owner === 'player2'
+    // even though moves[0].player === 'player1'
+    const moves = [
+      makeMove(0, 0, 'player1'),
+      makeMove(1, 0, 'player2'), // second move after swap decision
+    ]
+    const boardAfterSwap: BoardCell[][] = createEmptyBoard(5).map(row =>
+      row.map(cell => {
+        if (cell.row === 0 && cell.col === 0) return { ...cell, owner: 'player2' as const }
+        if (cell.row === 1 && cell.col === 0) return { ...cell, owner: 'player2' as const }
+        return cell
+      })
+    )
+    const game = makeGame(5, moves, {
+      board: boardAfterSwap,
+      config: { mode: 'pvp-local', boardSize: 5 as any, timerEnabled: false, pieRule: true },
+    })
+
+    const boardAtStep2 = getBoardAtStep(game, 2)
+    // After swap the contested stone should be owned by player2
+    expect(boardAtStep2[0][0].owner).toBe('player2')
+  })
+
+  it('pie rule swap: step 1 still shows original player1 stone (before decision)', () => {
+    const moves = [
+      makeMove(0, 0, 'player1'),
+      makeMove(1, 0, 'player2'),
+    ]
+    const boardAfterSwap: BoardCell[][] = createEmptyBoard(5).map(row =>
+      row.map(cell => {
+        if (cell.row === 0 && cell.col === 0) return { ...cell, owner: 'player2' as const }
+        if (cell.row === 1 && cell.col === 0) return { ...cell, owner: 'player2' as const }
+        return cell
+      })
+    )
+    const game = makeGame(5, moves, {
+      board: boardAfterSwap,
+      config: { mode: 'pvp-local', boardSize: 5 as any, timerEnabled: false, pieRule: true },
+    })
+
+    // At step 1, pie decision has not happened yet — stone is player1's
+    const boardAtStep1 = getBoardAtStep(game, 1)
+    expect(boardAtStep1[0][0].owner).toBe('player1')
+  })
+
+  it('no pie rule: stone ownership never changes', () => {
+    const moves = [makeMove(0, 0, 'player1'), makeMove(1, 0, 'player2')]
+    const game = makeGame(5, moves) // pieRule = undefined
+    const board = getBoardAtStep(game, 2)
+    expect(board[0][0].owner).toBe('player1')
+  })
+
+  it('intermediate steps produce distinct board states', () => {
+    const moves = [
+      makeMove(0, 0, 'player1'),
+      makeMove(1, 0, 'player2'),
+      makeMove(2, 0, 'player1'),
+    ]
+    const game = makeGame(5, moves)
+
+    const b1 = getBoardAtStep(game, 1)
+    const b2 = getBoardAtStep(game, 2)
+    const b3 = getBoardAtStep(game, 3)
+
+    // Each step adds exactly one more stone
+    const count = (b: BoardCell[][]) =>
+      b.flat().filter(c => c.owner !== null).length
+
+    expect(count(b1)).toBe(1)
+    expect(count(b2)).toBe(2)
+    expect(count(b3)).toBe(3)
+  })
+})

--- a/webapp/src/types/index.ts
+++ b/webapp/src/types/index.ts
@@ -98,6 +98,21 @@ export interface GameState {
   updatedAt: string
 }
 
+export interface GameSummary {
+  id: string
+  config: GameConfig
+  status: GameStatus
+  phase: GamePhase
+  players: {
+    player1: Player
+    player2: Player
+  }
+  winner: PlayerColor | null
+  moveCount: number
+  createdAt: string
+  updatedAt: string
+}
+
 // ==================== Chat ====================
 
 export interface ChatMessage {

--- a/webapp/src/utils/replayUtils.ts
+++ b/webapp/src/utils/replayUtils.ts
@@ -1,0 +1,60 @@
+import type { BoardCell, Move, GameState } from '@/types'
+
+/** Creates a fully empty triangular board of the given size. */
+export function createEmptyBoard(size: number): BoardCell[][] {
+  const board: BoardCell[][] = []
+  for (let row = 0; row < size; row++) {
+    board[row] = []
+    for (let col = 0; col <= row; col++) {
+      board[row][col] = { row, col, owner: null }
+    }
+  }
+  return board
+}
+
+/** Returns a new board with the given move applied (immutable). */
+export function applyMoveToBoard(board: BoardCell[][], move: Move): BoardCell[][] {
+  return board.map((row, rowIndex) =>
+    row.map((cell, colIndex) =>
+      rowIndex === move.row && colIndex === move.col
+        ? { ...cell, owner: move.player }
+        : cell
+    )
+  )
+}
+
+/**
+ * Reconstructs the board state after exactly `step` moves have been played.
+ *
+ * Pie Rule swap handling: if a swap occurred (detectable by comparing the
+ * first move's player to the final board's cell owner), the stone colour
+ * correction is applied starting from step 2 onward — matching the real
+ * game timeline where the decision happens after move 1.
+ */
+export function getBoardAtStep(game: GameState, step: number): BoardCell[][] {
+  const { boardSize } = game.config
+  let board = createEmptyBoard(boardSize)
+
+  const clampedStep = Math.max(0, Math.min(step, game.moves.length))
+  for (let i = 0; i < clampedStep; i++) {
+    board = applyMoveToBoard(board, game.moves[i])
+  }
+
+  // Detect and apply Pie Rule swap for step >= 2
+  if (clampedStep >= 2 && game.config.pieRule && game.moves.length > 0) {
+    const firstMove = game.moves[0]
+    const finalCell = game.board[firstMove.row]?.[firstMove.col]
+    if (finalCell?.owner && finalCell.owner !== firstMove.player) {
+      // Swap happened — update the contested stone's colour
+      board = board.map(row =>
+        row.map(cell =>
+          cell.row === firstMove.row && cell.col === firstMove.col && cell.owner !== null
+            ? { ...cell, owner: finalCell.owner }
+            : cell
+        )
+      )
+    }
+  }
+
+  return board
+}


### PR DESCRIPTION
 **Description**  
This PR introduces a game history feature along with a move-by-move replay system.

**Main Changes**
- Added a game history view for users  
- Introduced a replay screen to visualize games step by step  
- Enabled navigation between moves (controls and keyboard support)  
- Integrated access to history from the navigation bar  

**User Experience**
- Authenticated users can view their game history  
- Each game can be opened in replay mode  
- Smooth and intuitive move navigation  
- Clean interface focused on board visualization  

**Notes**
- Does not affect existing functionality  
- Compatible with previously stored games  

#close 146