### PR TITLE
Fix: Grafana behind Nginx subpath `/grafana/`feat: finally working

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ MARIADB_PASSWORD=your_db_password_here
 
 # JWT Secret (shared between users & game services)
 JWT_SECRET=your_jwt_secret_here
+
+# Grafana reverse proxy config (subpath behind Nginx)
+GF_SERVER_ROOT_URL=http://monitoring.localhost/grafana/

--- a/.env.shared
+++ b/.env.shared
@@ -1,3 +1,9 @@
+# Production environment values that are safe to commit (no secrets).
+# Loaded by CI/CD alongside .env (which holds secrets like DB passwords and JWT_SECRET).
+# Missing from here: MARIADB_ROOT_PASSWORD, MARIADB_USER, MARIADB_PASSWORD, JWT_SECRET —
+# those are injected as encrypted CI/CD secrets and must never be committed.
 VITE_USERS_API_URL=https://api.micrati.com/users
 VITE_GAME_API_URL=https://api.micrati.com/game
 VITE_INTEROP_API_URL=https://api.micrati.com/interop
+
+GF_SERVER_ROOT_URL=https://monitoring.micrati.com/grafana/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,8 +159,10 @@ services:
     volumes:
       - ./users/monitoring/grafana/provisioning:/etc/grafana/provisioning
     environment:
-      - GF_LOG_LEVEL=error
-      - GF_LOG_MODE=console
+      GF_LOG_LEVEL: error
+      GF_LOG_MODE: console
+      GF_SERVER_ROOT_URL: ${GF_SERVER_ROOT_URL}
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
     networks:
       - monitor-net
 

--- a/webapp/nginx/nginx.dev.conf
+++ b/webapp/nginx/nginx.dev.conf
@@ -75,11 +75,9 @@ server {
     }
 
     location /grafana/ {
-        proxy_pass http://grafana/;
+        proxy_pass http://grafana;
         include /etc/nginx/snippets/proxy-headers.conf;
         proxy_set_header Upgrade    $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_redirect / /grafana/;
-        proxy_redirect http:// /grafana/;
     }
 }

--- a/webapp/nginx/nginx.prod.conf
+++ b/webapp/nginx/nginx.prod.conf
@@ -109,11 +109,9 @@ server {
     }
     
     location /grafana/ {
-        proxy_pass http://grafana/;
+        proxy_pass http://grafana;
         include /etc/nginx/snippets/proxy-headers.conf;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_redirect / /grafana/;
-        proxy_redirect http:// /grafana/;
     }
 }


### PR DESCRIPTION
# Fix: Grafana behind Nginx subpath `/grafana/`

Fixes #157 

## Changes

### Nginx (`nginx.dev.conf`, `nginx.prod.conf`)
- `proxy_pass http://grafana/` → `http://grafana` (no trailing slash): prevents Nginx from stripping the path prefix before forwarding to Grafana.
- Removed `proxy_redirect` directives that were causing the redirect loop.

### Docker Compose
- Added environment variables to the Grafana service:
  - `GF_SERVER_ROOT_URL` — tells Grafana its real public URL (e.g. `http://monitoring.localhost/grafana/`).
  - `GF_SERVER_SERVE_FROM_SUB_PATH: "true"` — enables Grafana's native subpath support.

### Environment variables
- `.env.example`: added `GF_SERVER_ROOT_URL` so no one forgets it when setting up locally.
- `.env.shared`: production value (`https://monitoring.micrati.com/grafana/`), safe to commit (not a secret).

## Manual test

1. `docker-compose up --build`
2. Open `/grafana/` — loads correctly, login works, dashboards visible.

## Notes

Without `GF_SERVER_SERVE_FROM_SUB_PATH`, Grafana generates URLs without the `/grafana/` prefix and the proxy cannot resolve them. The trailing slash in `proxy_pass` causes Nginx to strip the path prefix before forwarding, which confuses the backend.