### PR TITLE
Show active games in history with resume option

### DIFF
--- a/webapp/src/i18n/en.ts
+++ b/webapp/src/i18n/en.ts
@@ -243,10 +243,12 @@ const en = {
     colBoard: 'Board',
     colMoves: 'Moves',
     colResult: 'Result',
+    resume: 'Resume',
     result: {
       win: 'Win',
       loss: 'Loss',
       draw: 'Draw',
+      active: 'In progress',
     },
     mode: {
       pve: 'vs Bot',

--- a/webapp/src/i18n/es.ts
+++ b/webapp/src/i18n/es.ts
@@ -241,10 +241,12 @@ const es = {
     colBoard: 'Tablero',
     colMoves: 'Jugadas',
     colResult: 'Resultado',
+    resume: 'Reanudar',
     result: {
       win: 'Victoria',
       loss: 'Derrota',
       draw: 'Empate',
+      active: 'En curso',
     },
     mode: {
       pve: 'vs Bot',

--- a/webapp/src/pages/GameHistoryPage.tsx
+++ b/webapp/src/pages/GameHistoryPage.tsx
@@ -50,9 +50,14 @@ function formatDate(iso: string): string {
 
 // ─── Row component ────────────────────────────────────────────────────────────
 
-function GameRow({ game, onReplay }: Readonly<{ game: GameSummary; onReplay: () => void }>) {
+function GameRow({ game, onReplay, onResume }: Readonly<{ 
+  game: GameSummary
+  onReplay: () => void
+  onResume: () => void 
+}>) {
   const { t } = useTranslation()
   const result = resultForGame(game, t)
+  const isActive = game.status === 'playing' 
 
   return (
     <tr className="border-b border-border last:border-0 hover:bg-muted/30 transition-colors">
@@ -86,28 +91,45 @@ function GameRow({ game, onReplay }: Readonly<{ game: GameSummary; onReplay: () 
 
       {/* Result */}
       <td className="py-3 pr-4">
-        <span className={cn('text-xs font-semibold px-2 py-0.5 rounded-full', result.className)}>
-          {result.label}
-        </span>
+        {isActive ? (
+          <span className="text-xs font-semibold px-2 py-0.5 rounded-full text-yellow-600 bg-yellow-500/10">
+            {t('history.result.active')}
+          </span>
+        ) : (
+          <span className={cn('text-xs font-semibold px-2 py-0.5 rounded-full', result.className)}>
+            {result.label}
+          </span>
+        )}
       </td>
 
       {/* Action */}
       <td className="py-3">
-        <Button
-          size="sm"
-          variant="ghost"
-          onClick={onReplay}
-          className="gap-1.5 h-7 text-xs"
-          disabled={game.moveCount === 0}
-        >
-          <Play className="w-3 h-3" />
-          {t('history.watchReplay')}
-        </Button>
+        {isActive ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onResume}
+            className="gap-1.5 h-7 text-xs text-primary"
+          >
+            <Play className="w-3 h-3" />
+            {t('history.resume')}
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onReplay}
+            className="gap-1.5 h-7 text-xs"
+            disabled={game.moveCount === 0}
+          >
+            <Play className="w-3 h-3" />
+            {t('history.watchReplay')}
+          </Button>
+        )}
       </td>
     </tr>
   )
 }
-
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export function GameHistoryPage() {
@@ -154,6 +176,7 @@ export function GameHistoryPage() {
                 key={game.id}
                 game={game}
                 onReplay={() => navigate(`/games/y/replay/${game.id}`)}
+                onResume={() => navigate(`/games/y/play/${game.id}`)}
               />
             ))}
           </tbody>

--- a/webapp/src/test/GameHistoryPage.test.tsx
+++ b/webapp/src/test/GameHistoryPage.test.tsx
@@ -224,7 +224,7 @@ describe('GameHistoryPage — active game', () => {
   it('clicking Resume navigates to the game page', () => {
     renderPage({ games: [makeSummary({ id: 'g1', status: 'playing', winner: null })] })
     fireEvent.click(screen.getByText('Resume'))
-    expect(mockNavigate).toHaveBeenCalledWith('/games/y/g1')
+    expect(mockNavigate).toHaveBeenCalledWith('/games/y/play/g1')
   })
 
   it('shows "In progress" badge instead of a result badge for an active game', () => {
@@ -260,7 +260,7 @@ describe('GameHistoryPage — active game', () => {
       ],
     })
     fireEvent.click(screen.getByText('Resume'))
-    expect(mockNavigate).toHaveBeenCalledWith('/games/y/active-game')
+    expect(mockNavigate).toHaveBeenCalledWith('/games/y/play/active-game')
   })
 })
 

--- a/webapp/src/test/GameHistoryPage.test.tsx
+++ b/webapp/src/test/GameHistoryPage.test.tsx
@@ -212,6 +212,58 @@ describe('GameHistoryPage — replay action', () => {
   })
 })
 
+// ─── Active game (resume) ─────────────────────────────────────────────────────
+
+describe('GameHistoryPage — active game', () => {
+  it('shows "Resume" button instead of "Replay" for an active game', () => {
+    renderPage({ games: [makeSummary({ status: 'playing', winner: null })] })
+    expect(screen.queryByText('Replay')).toBeNull()
+    expect(screen.getByText('Resume')).toBeDefined()
+  })
+
+  it('clicking Resume navigates to the game page', () => {
+    renderPage({ games: [makeSummary({ id: 'g1', status: 'playing', winner: null })] })
+    fireEvent.click(screen.getByText('Resume'))
+    expect(mockNavigate).toHaveBeenCalledWith('/games/y/g1')
+  })
+
+  it('shows "In progress" badge instead of a result badge for an active game', () => {
+    renderPage({ games: [makeSummary({ status: 'playing', winner: null })] })
+    expect(screen.getByText('In progress')).toBeDefined()
+    expect(screen.queryByText('Win')).toBeNull()
+    expect(screen.queryByText('Loss')).toBeNull()
+    expect(screen.queryByText('Draw')).toBeNull()
+  })
+
+  it('finished games still show Replay and not Resume', () => {
+    renderPage({ games: [makeSummary({ status: 'finished', winner: 'player1' })] })
+    expect(screen.getByText('Replay')).toBeDefined()
+    expect(screen.queryByText('Resume')).toBeNull()
+  })
+
+  it('shows Resume for active game mixed with Replay for finished game', () => {
+    renderPage({
+      games: [
+        makeSummary({ id: 'g1', status: 'playing', winner: null }),
+        makeSummary({ id: 'g2', status: 'finished', winner: 'player1' }),
+      ],
+    })
+    expect(screen.getByText('Resume')).toBeDefined()
+    expect(screen.getByText('Replay')).toBeDefined()
+  })
+
+  it('Resume navigates to the correct game when multiple games are listed', () => {
+    renderPage({
+      games: [
+        makeSummary({ id: 'active-game', status: 'playing', winner: null }),
+        makeSummary({ id: 'finished-game', status: 'finished', winner: 'player1' }),
+      ],
+    })
+    fireEvent.click(screen.getByText('Resume'))
+    expect(mockNavigate).toHaveBeenCalledWith('/games/y/active-game')
+  })
+})
+
 // ─── Guest upsell ─────────────────────────────────────────────────────────────
 
 describe('GameHistoryPage — guest view', () => {


### PR DESCRIPTION
## Problem
 
When a user left an ongoing game and came back later, the game was not easily discoverable. There was no way to resume it from the UI other than bookmarking or remembering the URL.
 
## Solution
 
Games with `status === 'playing'` now show a **Resume** button in the Game History table instead of the Replay button. A yellow "In progress" badge replaces the win/loss result chip for these games.
 
## Changes
 
**`webapp/src/pages/GameHistoryPage.tsx`**
- `GameRow` accepts a new `onResume` prop
- Detects active games via `game.status === 'playing'`
- Renders "In progress" badge and "Resume" button for active games
- Replay button remains for finished games (disabled if 0 moves)

**`webapp/src/i18n/en.ts` / `es.ts`**
- Added `history.resume` (`Resume` / `Reanudar`)
- Added `history.result.active` (`In progress` / `En curso`)

 