### PR TITLE
Fixed the broken OpenAPI file on the users module.

### DIFF
--- a/users/openapi.yaml
+++ b/users/openapi.yaml
@@ -153,7 +153,7 @@ paths:
                     example: Login successful
                   token:
                     type: string
-                    description: JWT token valid for 24 hours. Pass as `Authorization: Bearer <token>`.
+                    description: "JWT token valid for 24 hours. Pass as `Authorization: Bearer <token>`."
                     example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
                   user:
                     $ref: "#/components/schemas/UserProfileBasic"


### PR DESCRIPTION
Missing quotation marks on the OpenAPI documentation file for the users module made the module not fully deploy. The issue was fixed.